### PR TITLE
eos_l2_interfaces: convert items to strings before joing

### DIFF
--- a/plugins/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
@@ -238,7 +238,9 @@ def set_interface(want, have):
 
         allowed_vlans = want["trunk"].get("trunk_allowed_vlans")
         if allowed_vlans:
-            allowed_vlans = ",".join(["{0}".format(vlan) for vlan in allowed_vlans])
+            allowed_vlans = ",".join(
+                ["{0}".format(vlan) for vlan in allowed_vlans]
+            )
             commands.append(
                 "switchport trunk allowed vlan {0}".format(allowed_vlans)
             )

--- a/plugins/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
@@ -238,7 +238,7 @@ def set_interface(want, have):
 
         allowed_vlans = want["trunk"].get("trunk_allowed_vlans")
         if allowed_vlans:
-            allowed_vlans = ",".join(allowed_vlans)
+            allowed_vlans = ",".join(['{0}'.format(vlan) for vlan in allowed_vlans])
             commands.append(
                 "switchport trunk allowed vlan {0}".format(allowed_vlans)
             )

--- a/plugins/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
@@ -238,7 +238,7 @@ def set_interface(want, have):
 
         allowed_vlans = want["trunk"].get("trunk_allowed_vlans")
         if allowed_vlans:
-            allowed_vlans = ",".join(['{0}'.format(vlan) for vlan in allowed_vlans])
+            allowed_vlans = ",".join(["{0}".format(vlan) for vlan in allowed_vlans])
             commands.append(
                 "switchport trunk allowed vlan {0}".format(allowed_vlans)
             )

--- a/tests/integration/targets/eos_l2_interfaces/tests/cli/replaced.yaml
+++ b/tests/integration/targets/eos_l2_interfaces/tests/cli/replaced.yaml
@@ -9,6 +9,7 @@
           native_vlan: 20
           trunk_allowed_vlans:
             - 5-10
+            - 13
             - '15'
 
 - become: true

--- a/tests/integration/targets/eos_l2_interfaces/tests/cli/replaced.yaml
+++ b/tests/integration/targets/eos_l2_interfaces/tests/cli/replaced.yaml
@@ -9,7 +9,6 @@
           native_vlan: 20
           trunk_allowed_vlans:
             - 5-10
-            - 13
             - '15'
 
 - become: true

--- a/tests/unit/modules/network/eos/test_eos_l2_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_l2_interfaces.py
@@ -107,8 +107,9 @@ class TestEosL2InterfacesModule(TestEosModule):
                     dict(
                         name="Ethernet2",
                         mode="trunk",
-                        trunk=dict(native_vlan=50,
-                            trunk_allowed_vlans=[3, "5"]),
+                        trunk=dict(
+                            native_vlan=50, trunk_allowed_vlans=[3, "5"]
+                        ),
                     ),
                     dict(name="Ethernet3", access=dict(vlan=30)),
                 ],
@@ -118,7 +119,7 @@ class TestEosL2InterfacesModule(TestEosModule):
         commands = [
             "interface Ethernet2",
             "switchport trunk native vlan 50",
-            "switchport trunk allowed vlan 3,5"
+            "switchport trunk allowed vlan 3,5",
             "interface Ethernet3",
             "switchport access vlan 30",
         ]

--- a/tests/unit/modules/network/eos/test_eos_l2_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_l2_interfaces.py
@@ -107,7 +107,8 @@ class TestEosL2InterfacesModule(TestEosModule):
                     dict(
                         name="Ethernet2",
                         mode="trunk",
-                        trunk=dict(native_vlan=50),
+                        trunk=dict(native_vlan=50,
+                            trunk_allowed_vlans=[3, "5"]),
                     ),
                     dict(name="Ethernet3", access=dict(vlan=30)),
                 ],
@@ -117,6 +118,7 @@ class TestEosL2InterfacesModule(TestEosModule):
         commands = [
             "interface Ethernet2",
             "switchport trunk native vlan 50",
+            "switchport trunk allowed vlan 3,5"
             "interface Ethernet3",
             "switchport access vlan 30",
         ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #12 
When providing a list of vlans for trunk_allowed_vlans the list can contain vlan id:s represented as integers (much like the native_vlan parameter) however, the module expects a list of strings, this minor fix convert the items to strings before the join
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_l2_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
