### PR TITLE
eos: Fix idempotency issue with eos_vlans

### DIFF
--- a/plugins/module_utils/network/eos/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/eos/facts/vlans/vlans.py
@@ -101,7 +101,8 @@ class VlansFacts(object):
             config["vlan_id"] = vlan
             config["name"] = utils.parse_conf_arg(conf, "name")
             config["state"] = utils.parse_conf_arg(conf, "state")
-
+            if config["state"] is None:
+                config["state"] = "active"
             vlans.append(utils.remove_empties(config))
 
         return vlans

--- a/tests/integration/targets/eos_vlans/tests/cli/deleted.yaml
+++ b/tests/integration/targets/eos_vlans/tests/cli/deleted.yaml
@@ -36,6 +36,7 @@
 
       - vlan_id: 10
         name: ten
+        state: active
 
 - assert:
     that:

--- a/tests/integration/targets/eos_vlans/tests/cli/merged.yaml
+++ b/tests/integration/targets/eos_vlans/tests/cli/merged.yaml
@@ -37,6 +37,7 @@
 
       - vlan_id: 10
         name: ten
+        state: active
 
       - vlan_id: 20
         name: twenty

--- a/tests/integration/targets/eos_vlans/tests/cli/overridden.yaml
+++ b/tests/integration/targets/eos_vlans/tests/cli/overridden.yaml
@@ -9,6 +9,7 @@
 
       - vlan_id: 50
         name: fifty
+        state: active
 
 - become: true
   arista.eos.eos_facts:

--- a/tests/integration/targets/eos_vlans/tests/cli/replaced.yaml
+++ b/tests/integration/targets/eos_vlans/tests/cli/replaced.yaml
@@ -11,6 +11,7 @@
 
       - vlan_id: 10
         name: ten
+        state: active
 
 - become: true
   arista.eos.eos_facts:

--- a/tests/integration/targets/eos_vlans/tests/cli/reset_config.yml
+++ b/tests/integration/targets/eos_vlans/tests/cli/reset_config.yml
@@ -13,9 +13,11 @@
 
       - vlan_id: 10
         name: ten
+        state: active
 
       - vlan_id: 20
         name: twenty
+        state: active
 
 - assert:
     that:


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
Partially fixes https://github.com/ansible-collections/cisco.ios/issues/19

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
eos_vlans
##### ADDITIONAL INFORMATION

state = active was not gathered by facts. Fixed it.
