### PR TITLE
eos : Accomodates empty lines in banner text

### DIFF
--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -114,6 +114,7 @@ class Cliconf(CliconfBase):
         requests = []
         multiline = False
         for line in to_list(candidate):
+            # not line added to accomodate empty lines in banner
             if not isinstance(line, Mapping):
                 line = {"command": line}
 
@@ -128,7 +129,7 @@ class Cliconf(CliconfBase):
             if multiline:
                 line["sendonly"] = True
 
-            if cmd != "end" and cmd[0] != "!":
+            if cmd != "end" and not cmd.startswith("!"):
                 try:
                     results.append(self.send_command(**line))
                     requests.append(cmd)

--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -114,7 +114,6 @@ class Cliconf(CliconfBase):
         requests = []
         multiline = False
         for line in to_list(candidate):
-            # not line added to accomodate empty lines in banner
             if not isinstance(line, Mapping):
                 line = {"command": line}
 

--- a/tests/integration/targets/eos_banner/tests/cli/basic-login.yaml
+++ b/tests/integration/targets/eos_banner/tests/cli/basic-login.yaml
@@ -11,7 +11,7 @@
   register: result
   arista.eos.eos_banner: &id001
     banner: login
-    text: "Junk login banner\nover multiple lines\n"
+    text: "Junk login banner\n   \nover multiple lines\n"
     state: present
 
 - assert:

--- a/tests/unit/modules/network/eos/fixtures/eos_banner_show_banner.txt
+++ b/tests/unit/modules/network/eos/fixtures/eos_banner_show_banner.txt
@@ -1,3 +1,4 @@
 this is a sample
 mulitline banner
+
 used for testing


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

Depends-on: https://github.com/ansible-collections/arista.eos/pull/42
##### SUMMARY
Fixes #36 

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
cliconf/eos.py
##### ADDITIONAL INFORMATION

Empty lines in banner text was causing the issue. Fix added to accept the empty lines.

used playbook to validate the fix:
```
- name: given VLAN attributes with device configuration
      become: true
      vars:
        lines: |
          WARNING: This system is for the use of authorized clients only.
            Individuals using the computer network system without
            authorization, or in excess of their authorization, are
            subject to having all their activity on this computer
            network system monitored and recorded by system
            personnel.  To protect the computer network system from
            unauthorized use and to ensure the computer network systems
            is functioning properly, system administrators monitor this
            system.  Anyone using this computer network system
            expressly consents to such monitoring and is advised that
            if such monitoring reveals possible conduct of criminal
            activity, system personnel may provide the evidence of
            such activity to law enforcement officers.
            Access is restricted to authorized users only.

            Unauthorized access is a violation of state and federal,
            civil and criminal laws.
        line2: "This is an eos device"
      arista.eos.eos_banner:
        text: "{{ lines }}"
        banner: login

```
