### PR TITLE
Fix galaxy.yml to load correct README.md file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,6 +6,6 @@ dependencies:
 license_file: LICENSE
 name: eos
 namespace: arista
-readme: README.rst
+readme: README.md
 repository: https://github.com/ansible-collections/arista.eos
 tags: [arista, eos, networking, eapi]


### PR DESCRIPTION
We should have caught this via our build-ansible-collections jobs, but
don't. I've started work on updating our jobs to properly test galaxy
imports.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>