### PR TITLE
[eos_l3_interfaces] Fixes sort issue in presence of secondary ipv4 address

### DIFF
--- a/changelogs/fragments/68-fix-sort-l3-int.yaml
+++ b/changelogs/fragments/68-fix-sort-l3-int.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Sorted the list of params of ip address before forming the tuple.

--- a/plugins/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
@@ -255,10 +255,10 @@ def set_interface(want, have):
     commands = []
 
     want_ipv4 = set(
-        tuple(address.items()) for address in want.get("ipv4") or []
+        tuple(sorted(address.items())) for address in want.get("ipv4") or []
     )
     have_ipv4 = set(
-        tuple(address.items()) for address in have.get("ipv4") or []
+        tuple(sorted(address.items())) for address in have.get("ipv4") or []
     )
     for address in want_ipv4 - have_ipv4:
         address = dict(address)
@@ -273,10 +273,10 @@ def set_interface(want, have):
         commands.append(address_cmd)
 
     want_ipv6 = set(
-        tuple(address.items()) for address in want.get("ipv6") or []
+        tuple(sorted(address.items())) for address in want.get("ipv6") or []
     )
     have_ipv6 = set(
-        tuple(address.items()) for address in have.get("ipv6") or []
+        tuple(sorted(address.items())) for address in have.get("ipv6") or []
     )
     for address in want_ipv6 - have_ipv6:
         address = dict(address)
@@ -288,10 +288,10 @@ def clear_interface(want, have):
     commands = []
 
     want_ipv4 = set(
-        tuple(address.items()) for address in want.get("ipv4") or []
+        tuple(sorted(address.items())) for address in want.get("ipv4") or []
     )
     have_ipv4 = set(
-        tuple(address.items()) for address in have.get("ipv4") or []
+        tuple(sorted(address.items())) for address in have.get("ipv4") or []
     )
     if not want_ipv4 and have_ipv4:
         commands.append("no ip address")
@@ -312,10 +312,10 @@ def clear_interface(want, have):
                 break
 
     want_ipv6 = set(
-        tuple(address.items()) for address in want.get("ipv6") or []
+        tuple(sorted(address.items())) for address in want.get("ipv6") or []
     )
     have_ipv6 = set(
-        tuple(address.items()) for address in have.get("ipv6") or []
+        tuple(sorted(address.items())) for address in have.get("ipv6") or []
     )
     for address in have_ipv6 - want_ipv6:
         address = dict(address)

--- a/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
@@ -79,5 +79,4 @@
 
 - name: Assert that config was reverted
   assert:
-    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) |length\
-      \ == 0 }}"
+    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) == [] }}"

--- a/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
@@ -1,0 +1,84 @@
+---
+- include_tasks: _reset_config.yaml
+
+- set_fact:
+    config1:
+
+      - name: Ethernet1
+        ipv4:
+
+          - address: 198.51.100.14/24
+
+    config2:
+
+      - name: Ethernet2
+        ipv4:
+
+          - address: 203.0.113.227/31
+
+- name: Merge provided configuration with device configuration (base config).
+  register: baseconfig
+  become: true
+  arista.eos.eos_l3_interfaces:
+    config: '{{ config1 }}'
+    state: merged
+
+- become: true
+  arista.eos.eos_facts:
+    gather_network_resources: l3_interfaces
+
+- assert:
+    that:
+      - ansible_facts.network_resources.l3_interfaces|symmetric_difference(baseconfig.after)
+        == []
+  become: true
+
+- name: Merge provided configuration with device configuration (config to be reverted).
+  register: result
+  become: true
+  arista.eos.eos_l3_interfaces:
+    config: '{{ config2 }}'
+    state: merged
+
+
+- set_fact:
+    expected_config:
+
+      - name: Ethernet1
+        ipv4:
+
+          - address: 198.51.100.14/24
+
+          - address: 203.0.113.27/31
+            secondary: true
+
+      - name: Ethernet2
+        ipv4:
+
+          - address: 203.0.113.227/31
+        ipv6:
+
+          - address: 2001:db8::1/64
+
+      - name: Management1
+        ipv4:
+
+          - address: dhcp
+
+- assert:
+    that:
+      - result.after|symmetric_difference(expected_config)
+        == []
+
+- name: Revert back to base config using facts round trip
+  become: true
+  register: revert
+  arista.eos.eos_l3_interfaces:
+    config: "{{ ansible_facts['network_resources']['l3_interfaces'] }}"
+    state: overridden
+
+- name: Assert that config was reverted
+  assert:
+    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) |length\
+      \ == 0 }}"
+

--- a/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
@@ -81,4 +81,3 @@
   assert:
     that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) |length\
       \ == 0 }}"
-


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/611
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/612
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
Fixes #67 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
eos_l3_interfaces.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
