### PR TITLE
[eos]: Add round trip testcase to 2.9 resource modules

### DIFF
--- a/changelogs/fragments/72-add-rtt.yaml
+++ b/changelogs/fragments/72-add-rtt.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add round trip testcases to the 2.9 resource modules.

--- a/plugins/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
@@ -255,10 +255,10 @@ def set_interface(want, have):
     commands = []
 
     want_ipv4 = set(
-        tuple(address.items()) for address in want.get("ipv4") or []
+        tuple(sorted(address.items())) for address in want.get("ipv4") or []
     )
     have_ipv4 = set(
-        tuple(address.items()) for address in have.get("ipv4") or []
+        tuple(sorted(address.items())) for address in have.get("ipv4") or []
     )
     for address in want_ipv4 - have_ipv4:
         address = dict(address)
@@ -286,12 +286,11 @@ def set_interface(want, have):
 
 def clear_interface(want, have):
     commands = []
-
     want_ipv4 = set(
-        tuple(address.items()) for address in want.get("ipv4") or []
+        tuple(sorted(address.items())) for address in want.get("ipv4") or []
     )
     have_ipv4 = set(
-        tuple(address.items()) for address in have.get("ipv4") or []
+        tuple(sorted(address.items())) for address in have.get("ipv4") or []
     )
     if not want_ipv4 and have_ipv4:
         commands.append("no ip address")

--- a/tests/integration/targets/eos_acl_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_acl_interfaces/tests/common/rtt.yaml
@@ -63,8 +63,7 @@
     - name: Assert that changes were applied
       assert:
         that:
-          - "{{ round_trip['commands'] | symmetric_difference(result['commands'])\
-            \ |length == 0 }}"
+          - "{{ round_trip['commands'] | symmetric_difference(result['commands']) == [] }}"
 
     - name: Revert back to base config using facts round trip
       become: true
@@ -75,8 +74,7 @@
 
     - name: Assert that config was reverted
       assert:
-        that: "{{ base_config['after'] | symmetric_difference(revert['after']) |length\
-          \ == 0 }}"
+        that: "{{ base_config['after'] | symmetric_difference(revert['after']) == [] }}"
 
 
   always:

--- a/tests/integration/targets/eos_acl_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_acl_interfaces/tests/common/rtt.yaml
@@ -1,0 +1,84 @@
+---
+- debug:
+    msg: Start eos_acl_interfaces merged round trip tests ansible_connection={{
+      ansible_connection }}
+
+- block:
+
+    - name: merge given acl interfaces configuration(apply base config)
+      become: true
+      register: base_config
+      arista.eos.eos_acl_interfaces:
+        config:
+
+          - name: "{{ Interfaces['int1'] }}"
+            access_groups:
+
+              - afi: ipv4
+                acls:
+
+                  - name: aclv401
+                    direction: in
+
+                  - name: aclv402
+                    direction: out
+
+              - afi: ipv6
+                acls:
+
+                  - name: aclv601
+                    direction: out
+
+          - name: "{{ Interfaces['int2'] }}"
+            access_groups:
+
+              - afi: ipv6
+                acls:
+
+                  - name: aclv601
+                    direction: in
+        state: merged
+
+    - assert:
+        that:
+          - result.commands|length == 6
+          - result.changed == true
+          - result.commands|symmetric_difference(merged.commands) == []
+
+    - name: Apply the provided configuration (config to be reverted)
+      become: true
+      register: result
+      arista.eos.eos_acl_interfaces:
+        config:
+
+          - name: "{{ Interfaces['int2'] }}"
+            access_groups:
+
+              - afi: ipv4
+                acls:
+
+                  - name: aclv401
+                    direction: in
+
+    - name: Assert that changes were applied
+      assert:
+        that:
+          - "{{ round_trip['commands'] | symmetric_difference(result['commands'])\
+            \ |length == 0 }}"
+
+    - name: Revert back to base config using facts round trip
+      become: true
+      register: revert
+      arista.eos.eos_acl_interfaces:
+        config: "{{ ansible_facts['network_resources']['acl_interfaces'] }}"
+        state: overridden
+
+    - name: Assert that config was reverted
+      assert:
+        that: "{{ base_config['after'] | symmetric_difference(revert['after']) |length\
+          \ == 0 }}"
+
+
+  always:
+
+    - include_tasks: _remove_config.yaml

--- a/tests/integration/targets/eos_acl_interfaces/vars/main.yaml
+++ b/tests/integration/targets/eos_acl_interfaces/vars/main.yaml
@@ -30,6 +30,10 @@ overridden:
     - interface GigabitEthernet0/1
     - no ipv6 traffic-filter aclv601 in
     - ip access-group aclv401 in
+roundtrip:
+  commands:
+    - interface GigabitEthernet0/1
+    - ip access-group aclv401 in
 gathered:
   config:
     - name: Loopback888

--- a/tests/integration/targets/eos_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_interfaces/tests/common/rtt.yaml
@@ -26,8 +26,7 @@
 
 - assert:
     that:
-      - ansible_facts.network_resources.interfaces|symmetric_difference(baseconfig.after)|length
-        == 0
+      - ansible_facts.network_resources.interfaces|symmetric_difference(baseconfig.after) == []
 
 - name: Apply the provided configuration (config to be reverted)
   become: true
@@ -54,8 +53,7 @@
 
 - assert:
     that:
-      - expected_config|difference(result.after)|length
-        == 0
+      - expected_config|difference(result.after) == []
 
 - name: Revert back to base config using facts round trip
   become: true

--- a/tests/integration/targets/eos_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_interfaces/tests/common/rtt.yaml
@@ -66,8 +66,4 @@
 
 - name: Assert that config was reverted
   assert:
-    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) |length\
-      \ == 0 }}"
-
-
-
+    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) == [] }}"

--- a/tests/integration/targets/eos_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_interfaces/tests/common/rtt.yaml
@@ -1,0 +1,73 @@
+---
+- include_tasks: _reset_config.yaml
+
+- set_fact:
+    config1:
+      - name: Ethernet2
+        description: Configured by Ansible
+        speed: '10'
+        duplex: full
+        enabled: false
+    config2:
+      - name: Ethernet1
+        enabled: true
+        description: Config to be reverted
+
+- name: Merge provided configuration with device configuration( Base config )
+  register: baseconfig
+  become: true
+  arista.eos.eos_interfaces:
+    config: '{{ config1 }}'
+    state: merged
+
+- become: true
+  arista.eos.eos_facts:
+    gather_network_resources: interfaces
+
+- assert:
+    that:
+      - ansible_facts.network_resources.interfaces|symmetric_difference(baseconfig.after)|length
+        == 0
+
+- name: Apply the provided configuration (config to be reverted)
+  become: true
+  register: result
+  arista.eos.eos_interfaces:
+    config: '{{ config2 }}'
+    state: merged
+
+- set_fact:
+    expected_config:
+
+      - name: Ethernet1
+        description: Config to be reverted
+        speed: 40g
+        duplex: full
+        enabled: true
+
+      - name: Ethernet2
+        description: Configured by Ansible
+        speed: '10'
+        duplex: full
+        enabled: false
+        mtu: '3000'
+
+- assert:
+    that:
+      - expected_config|difference(result.after)|length
+        == 0
+
+- name: Revert back to base config using facts round trip
+  become: true
+  register: revert
+  arista.eos.eos_interfaces:
+    config: "{{ ansible_facts['network_resources']['interfaces'] }}"
+    state: overridden
+
+- name: Assert that config was reverted
+  assert:
+    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) |length\
+      \ == 0 }}"
+
+
+

--- a/tests/integration/targets/eos_l2_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_l2_interfaces/tests/common/rtt.yaml
@@ -72,5 +72,4 @@
 
 - name: Assert that config was reverted
   assert:
-    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) |length\
-      \ == 0 }}"
+    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) == [] }}"

--- a/tests/integration/targets/eos_l2_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_l2_interfaces/tests/common/rtt.yaml
@@ -1,0 +1,76 @@
+---
+- include_tasks: _reset_config.yaml
+
+- set_fact:
+    config1:
+
+      - name: Ethernet1
+        mode: trunk
+        trunk:
+          native_vlan: 10
+
+    config2:
+
+      - name: Ethernet2
+        access:
+          vlan: 30
+
+- name: Merge provided configuration with device configuration (base config)
+  register: baseconfig
+  become: true
+  arista.eos.eos_l2_interfaces:
+    config: '{{ config1 }}'
+    state: merged
+
+- become: true
+  arista.eos.eos_facts:
+    gather_network_resources: l2_interfaces
+
+- assert:
+    that:
+      - ansible_facts.network_resources.l2_interfaces|symmetric_difference(baseconfig.after)
+        == []
+
+- name: Apply the provided configuration (config to be reverted)
+  register: result
+  become: true
+  arista.eos.eos_l2_interfaces:
+    config: '{{ config2 }}'
+    state: merged
+
+
+- set_fact:
+    expected_config:
+
+      - name: Ethernet1
+        mode: trunk
+        access:
+          vlan: 20
+        trunk:
+          native_vlan: 10
+
+      - name: Ethernet2
+        mode: trunk
+        access:
+          vlan: 30
+        trunk:
+          native_vlan: 20
+
+      - name: Management1
+
+- assert:
+    that:
+      - result.after|symmetric_difference(expected_config)
+        == []
+
+- name: Revert back to base config using facts round trip
+  become: true
+  register: revert
+  arista.eos.eos_l2_interfaces:
+    config: "{{ ansible_facts['network_resources']['l2_interfaces'] }}"
+    state: overridden
+
+- name: Assert that config was reverted
+  assert:
+    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) |length\
+      \ == 0 }}"

--- a/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
@@ -79,6 +79,4 @@
 
 - name: Assert that config was reverted
   assert:
-    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) |length\
-      \ == 0 }}"
-
+    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) == [] }}"

--- a/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tests/common/rtt.yaml
@@ -1,0 +1,84 @@
+---
+- include_tasks: _reset_config.yaml
+
+- set_fact:
+    config1:
+
+      - name: Ethernet1
+        ipv4:
+
+          - address: 198.51.100.14/24
+
+    config2:
+
+      - name: Ethernet2
+        ipv4:
+
+          - address: 203.0.113.227/31
+
+- name: Merge provided configuration with device configuration (base config).
+  register: baseconfig
+  become: true
+  arista.eos.eos_l3_interfaces:
+    config: '{{ config1 }}'
+    state: merged
+
+- become: true
+  arista.eos.eos_facts:
+    gather_network_resources: l3_interfaces
+
+- assert:
+    that:
+      - ansible_facts.network_resources.l3_interfaces|symmetric_difference(baseconfig.after)
+        == []
+  become: true
+
+- name: Merge provided configuration with device configuration (config to be reverted).
+  register: result
+  become: true
+  arista.eos.eos_l3_interfaces:
+    config: '{{ config2 }}'
+    state: merged
+
+
+- set_fact:
+    expected_config:
+
+      - name: Ethernet1
+        ipv4:
+
+          - address: 198.51.100.14/24
+
+          - address: 203.0.113.27/31
+            secondary: true
+
+      - name: Ethernet2
+        ipv4:
+
+          - address: 203.0.113.227/31
+        ipv6:
+
+          - address: 2001:db8::1/64
+
+      - name: Management1
+        ipv4:
+
+          - address: dhcp
+
+- assert:
+    that:
+      - result.after|symmetric_difference(expected_config)
+        == []
+
+- name: Revert back to base config using facts round trip
+  become: true
+  register: revert
+  arista.eos.eos_l3_interfaces:
+    config: "{{ ansible_facts['network_resources']['l3_interfaces'] }}"
+    state: overridden
+
+- name: Assert that config was reverted
+  assert:
+    that: "{{ baseconfig['after'] | symmetric_difference(revert['after']) |length\
+      \ == 0 }}"
+

--- a/tests/integration/targets/eos_lacp_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tests/common/rtt.yaml
@@ -1,0 +1,64 @@
+---
+- include_tasks: _reset_config.yaml
+
+- set_fact:
+    config1:
+
+      - name: Ethernet1
+        rate: fast
+
+    config2:
+      - name: Ethernet2
+        port_priority: 20
+        rate: fast
+
+
+- name: Merge provided configuration with device configuration (base config)
+  register: baseconfig
+  become: true
+  arista.eos.eos_lacp_interfaces:
+    config: '{{ config1 }}'
+    state: merged
+
+- become: true
+  arista.eos.eos_facts:
+    gather_network_resources: lacp_interfaces
+
+- assert:
+    that:
+      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(baseconfig.after)
+        == []
+
+- name: Merge provided configuration with device configuration
+  register: result
+  become: true
+  arista.eos.eos_lacp_interfaces:
+    config: '{{ config2 }}'
+    state: merged
+
+
+- set_fact:
+    expected_config:
+
+      - name: Ethernet1
+        port_priority: 30
+        rate: fast
+
+      - name: Ethernet2
+        port_priority: 20
+        rate: fast
+
+- assert:
+    that:
+      - expected_config|symmetric_difference(result.after) == []
+
+- name: Revert back to base config using facts round trip
+  become: true
+  register: revert
+  arista.eos.eos_lacp_interfaces:
+    config: "{{ ansible_facts['network_resources']['lacp_interfaces'] }}"
+    state: overridden
+
+- name: Assert that config was reverted
+  assert:
+    that: "{{ baseconfig.after | symmetric_difference(revert.after) == [] }}"

--- a/tests/integration/targets/eos_lldp_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_lldp_interfaces/tests/common/rtt.yaml
@@ -1,0 +1,63 @@
+---
+- include_tasks: _reset_config.yaml
+
+- set_fact:
+    config1:
+
+      - name: Ethernet1
+        transmit: false
+
+    config2:
+
+      - name: Ethernet2
+        receive: false
+
+- name: Merge provided configuration with device configuration(base config).
+  register: baseconfig
+  become: true
+  arista.eos.eos_lldp_interfaces:
+    config: '{{ config1 }}'
+    state: merged
+
+- become: true
+  arista.eos.eos_facts:
+    gather_network_resources: lldp_interfaces
+
+- assert:
+    that:
+      - ansible_facts.network_resources.lldp_interfaces|symmetric_difference(baseconfig.after)
+        == []
+
+- name: Merge provided configuration with device configuration(config to be reverted).
+  register: result
+  become: true
+  arista.eos.eos_lldp_interfaces:
+    config: '{{ config2 }}'
+    state: merged
+
+
+- set_fact:
+    expected_config:
+
+      - name: Ethernet1
+        transmit: false
+        receive: false
+
+      - name: Ethernet2
+        transmit: false
+        receive: false
+
+- assert:
+    that:
+      - expected_config|symmetric_difference(result.after) == []
+
+- name: Revert back to base config using facts round trip
+  become: true
+  register: revert
+  arista.eos.eos_lldp_interfaces:
+    config: "{{ ansible_facts['network_resources']['lldp_interfaces'] }}"
+    state: overridden
+
+- name: Assert that config was reverted
+  assert:
+    that: baseconfig.after == revert.after

--- a/tests/integration/targets/eos_vlans/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_vlans/tests/common/rtt.yaml
@@ -8,7 +8,6 @@
         state: suspend
 
     config2:
-      
       - vlan_id: 30
         name: thirty
 

--- a/tests/integration/targets/eos_vlans/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_vlans/tests/common/rtt.yaml
@@ -1,0 +1,68 @@
+---
+- include_tasks: _reset_config.yaml
+
+- set_fact:
+    config1:
+
+      - vlan_id: 20
+        state: suspend
+
+    config2:
+      
+      - vlan_id: 30
+        name: thirty
+
+- name: Merge provided configuration with device configuration(base config).
+  register: baseconfig
+  become: true
+  arista.eos.eos_vlans:
+    config: '{{ config1 }}'
+    state: merged
+
+- become: true
+  arista.eos.eos_facts:
+    gather_network_resources: vlans
+
+- assert:
+    that:
+      - ansible_facts.network_resources.vlans|symmetric_difference(baseconfig.after)
+        == []
+
+- name: Merge provided configuration with device configuration(config to be reverted).
+  register: result
+  become: true
+  arista.eos.eos_vlans:
+    config: '{{ config2 }}'
+    state: merged
+
+
+- set_fact:
+    expected_config:
+
+      - vlan_id: 10
+        name: ten
+        state: active
+
+      - vlan_id: 20
+        name: twenty
+        state: suspend
+
+      - vlan_id: 30
+        name: thirty
+        state: active
+
+- assert:
+    that:
+      - expected_config|symmetric_difference(result.after)
+        == []
+
+- name: Revert back to base config using facts round trip
+  become: true
+  register: revert
+  arista.eos.eos_vlans:
+    config: "{{ ansible_facts['network_resources']['vlans'] }}"
+    state: overridden
+
+- name: Assert that config was reverted
+  assert:
+    that: baseconfig.after == revert.after


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/594
##### SUMMARY
Round trip testcase is added as part of the integration test suite for the following RMs

- eos_interfaces
- eos_l2_interfaces
- eos_l3_interfaces
- eos_lacp_interfaces
- eos_lldp_interfaces
- eos_vlans



