### PR TITLE
update documentation to provide working examples.

### DIFF
--- a/plugins/modules/eos_lag_interfaces.py
+++ b/plugins/modules/eos_lag_interfaces.py
@@ -111,7 +111,7 @@ EXAMPLES = """
 - name: Merge provided LAG attributes with existing device configuration
   arista.eos.eos_lag_interfaces:
     config:
-    - name: 5
+    - name: Port-Channel5
       members:
       - member: Ethernet2
         mode: on
@@ -140,7 +140,7 @@ EXAMPLES = """
 - name: Replace all device configuration of specified LAGs with provided configuration
   arista.eos.eos_lag_interfaces:
     config:
-    - name: 5
+    - name: Port-Channel5
       members:
       - member: Ethernet2
         mode: on
@@ -168,7 +168,7 @@ EXAMPLES = """
 - name: Override all device configuration of all LAG attributes with provided configuration
   arista.eos.eos_lag_interfaces:
     config:
-    - name: 10
+    - name: Port-Channel10
       members:
       - member: Ethernet2
         mode: on
@@ -197,7 +197,7 @@ EXAMPLES = """
 - name: Delete LAG attributes of the given interfaces.
   arista.eos.eos_lag_interfaces:
     config:
-    - name: 5
+    - name: Port-Channel5
       members:
       - member: Ethernet1
     state: deleted
@@ -225,7 +225,7 @@ EXAMPLES = """
 
 # Output:
 #   parsed:
-#     - name: 5
+#     - name: Port-Channel5
 #       members:
 #         - member: Ethernet2
 #           mode: on
@@ -237,7 +237,7 @@ EXAMPLES = """
 - name: Use Rendered to convert the structured data to native config
   arista.eos.eos_lag_interfaces:
     config:
-    - name: 5
+    - name: Port-Channel5
       members:
       - member: Ethernet2
         mode: on
@@ -270,7 +270,7 @@ EXAMPLES = """
 
 # Output:
 #   gathered:
-#     - name: 5
+#     - name: Port-Channel5
 #       members:
 #         - member: Ethernet2
 #           mode: on


### PR DESCRIPTION
##### SUMMARY
The examples in the documentation don't work as described in the documentation the name in the form of Port-channel5 and not just 5.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
arista.eos.eos_lag_interface

##### ADDITIONAL INFORMATION
The given example won't work the corrected do. Tested on:
```
ansible 2.9.10
  config file = /home/dvdsanden/poc/vEOS/ansible.cfg
  configured module search path = ['/home/dvdsanden/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dvdsanden/poc/vEOS/venv/lib/python3.7/site-packages/ansible
  executable location = /home/dvdsanden/poc/vEOS/venv/bin/ansible
  python version = 3.7.5 (default, Oct 17 2019, 12:25:15) [GCC 8.3.0]
```