### PR TITLE
Print out what changes are needed to satisfy linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
 [testenv:linters]
 install_command = pip install {opts} {packages}
 commands =
-  black -v -l79 --check {toxinidir}
+  black -v -l79 --diff --check {toxinidir}
   flake8 {posargs}
   yamllint -s .
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/595

Just outputting that a file needs to be changed, with no hint to the
developer as to what needs to be changed is not useful.
