### PR TITLE
Fix test tag for eos_smoke

### DIFF
--- a/tests/integration/targets/eos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/eos_smoke/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags: network_cli
 
 - name: run test cases (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: local

--- a/tests/integration/targets/eos_smoke/tasks/main.yaml
+++ b/tests/integration/targets/eos_smoke/tasks/main.yaml
@@ -1,7 +1,5 @@
 ---
 - include: cli.yaml
-  tags:
-    - network_cli
 
 - include: eapi.yaml
   tags:


### PR DESCRIPTION
This results in local test jobs running with network_cli, causing job
timeouts.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>