### PR TITLE
Revert "Allow --diff and --check to coexist on eos_config (#91)"

### DIFF
--- a/changelogs/fragments/91-check-diff.yaml
+++ b/changelogs/fragments/91-check-diff.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - eos_config - Enable --diff when --check is also specified

--- a/plugins/modules/eos_config.py
+++ b/plugins/modules/eos_config.py
@@ -511,7 +511,13 @@ def main():
         )
 
         if module.params["diff_against"] == "running":
-            contents = config.config_text
+            if module.check_mode:
+                module.warn(
+                    "unable to perform diff against running-config due to check mode"
+                )
+                contents = None
+            else:
+                contents = config.config_text
 
         elif module.params["diff_against"] == "startup":
             if not startup_config:


### PR DESCRIPTION
This reverts commit c20a1fc32b83eff2898ad5394accc16b246a765e.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This gains nothing on non-onbox-diff devices

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_config