### PR TITLE
lag_interfaces: Handled change mode stdout error

### DIFF
--- a/changelogs/fragments/96-changemode-terminalerror.yaml
+++ b/changelogs/fragments/96-changemode-terminalerror.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Added error pattern to the terminal plugin to handle change mode error seen in lag interfaces config.

--- a/plugins/terminal/eos.py
+++ b/plugins/terminal/eos.py
@@ -52,7 +52,14 @@ class TerminalModule(TerminalBase):
         re.compile(br"% Subnet [0-9a-f.:/]+ overlaps", re.I),
         re.compile(br"Maximum number of pending sessions has been reached"),
         re.compile(br"% Prefix length must be less than"),
-        # terminal error when a configured port-channel's mode is modified.
+        # terminal error when a configured channel-group's mode is modified.
+        # 
+        # veos(config-if-Et2)#show active 
+        # interface Ethernet2
+        # channel-group 15 mode on
+        # -----------------------------
+        # veos(config-if-Et2)#channel-group 15 mode active
+        # % Cannot change mode; remove all members and try again.
         re.compile(
             br"% Cannot change mode; remove all members and try again."
         ),

--- a/plugins/terminal/eos.py
+++ b/plugins/terminal/eos.py
@@ -52,6 +52,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"% Subnet [0-9a-f.:/]+ overlaps", re.I),
         re.compile(br"Maximum number of pending sessions has been reached"),
         re.compile(br"% Prefix length must be less than"),
+        re.compile(br"% Cannot change mode; remove all members and try again.", re.I),
     ]
 
     def on_open_shell(self):

--- a/plugins/terminal/eos.py
+++ b/plugins/terminal/eos.py
@@ -52,8 +52,9 @@ class TerminalModule(TerminalBase):
         re.compile(br"% Subnet [0-9a-f.:/]+ overlaps", re.I),
         re.compile(br"Maximum number of pending sessions has been reached"),
         re.compile(br"% Prefix length must be less than"),
+        # terminal error when a configured port-channel's mode is modified.
         re.compile(
-            br"% Cannot change mode; remove all members and try again.", re.I
+            br"% Cannot change mode; remove all members and try again."
         ),
     ]
 

--- a/plugins/terminal/eos.py
+++ b/plugins/terminal/eos.py
@@ -52,14 +52,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"% Subnet [0-9a-f.:/]+ overlaps", re.I),
         re.compile(br"Maximum number of pending sessions has been reached"),
         re.compile(br"% Prefix length must be less than"),
-        # terminal error when a configured channel-group's mode is modified.
-        # 
-        # veos(config-if-Et2)#show active 
-        # interface Ethernet2
-        # channel-group 15 mode on
-        # -----------------------------
-        # veos(config-if-Et2)#channel-group 15 mode active
-        # % Cannot change mode; remove all members and try again.
+        # returned in response to 'channel-group <name> mode <mode>'
         re.compile(
             br"% Cannot change mode; remove all members and try again."
         ),

--- a/plugins/terminal/eos.py
+++ b/plugins/terminal/eos.py
@@ -52,7 +52,9 @@ class TerminalModule(TerminalBase):
         re.compile(br"% Subnet [0-9a-f.:/]+ overlaps", re.I),
         re.compile(br"Maximum number of pending sessions has been reached"),
         re.compile(br"% Prefix length must be less than"),
-        re.compile(br"% Cannot change mode; remove all members and try again.", re.I),
+        re.compile(
+            br"% Cannot change mode; remove all members and try again.", re.I
+        ),
     ]
 
     def on_open_shell(self):

--- a/tests/integration/targets/eos_lag_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/eos_lag_interfaces/tests/cli/merged.yaml
@@ -10,6 +10,13 @@
           - member: Ethernet2
             mode: 'on'
 
+    change_config:
+      - name: Port-Channel5
+        members:
+
+          - member: Ethernet2
+            mode: 'passive'
+
 - become: true
   arista.eos.eos_facts:
     gather_network_resources: lag_interfaces
@@ -51,3 +58,17 @@
     that:
       - ansible_facts.network_resources.lag_interfaces|symmetric_difference(expected_config)|length
         == 0
+
+- name: Merge provided configuration with device configuration, expect error.
+  become: true
+  ignore_errors: true
+  register: result
+  arista.eos.eos_lag_interfaces:
+    config: '{{ change_config }}'
+    state: merged
+
+- assert:
+    that:
+      - result.failed == true
+      - result.msg is defined
+      - '"Cannot change mode" in result.module_stderr'


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/115
##### SUMMARY
related to  #95 

Handled the terminal output error **% Cannot change mode; remove all members and try again.**

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
terminal/eos.py

