### PR TITLE
Add documentation to use the l2_interfaces module for L2 configs, in l3_interfaces module.

### DIFF
--- a/changelogs/fragments/101-l3_interfaces_documentation.yaml
+++ b/changelogs/fragments/101-l3_interfaces_documentation.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Documentated the necessity to use eos_l2_interfaces (for l2 configs) in eos_l3_interfaces module.

--- a/changelogs/fragments/101-l3_interfaces_documentation.yaml
+++ b/changelogs/fragments/101-l3_interfaces_documentation.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Documentated the necessity to use eos_l2_interfaces (for l2 configs) in eos_l3_interfaces module.
+  - Documented the necessity to use eos_interfaces and eos_l2_interfaces (for l2 configs) in eos_l3_interfaces module.

--- a/plugins/modules/eos_l3_interfaces.py
+++ b/plugins/modules/eos_l3_interfaces.py
@@ -41,7 +41,7 @@ author: Nathaniel Case (@qalthos)
 notes:
 - Tested against Arista EOS 4.20.10M
 - This module works with connection C(network_cli). See the L(EOS Platform Options,../network/user_guide/platform_eos.html).
-  'eos_l2_interfaces/eos_interfaces' should be used for preparing the node , before applying L3 configurations using
+  'eos_l2_interfaces/eos_interfaces' should be used for preparing the interfaces , before applying L3 configurations using
   this module (eos_l3_interfaces).
 options:
   config:

--- a/plugins/modules/eos_l3_interfaces.py
+++ b/plugins/modules/eos_l3_interfaces.py
@@ -41,6 +41,8 @@ author: Nathaniel Case (@qalthos)
 notes:
 - Tested against Arista EOS 4.20.10M
 - This module works with connection C(network_cli). See the L(EOS Platform Options,../network/user_guide/platform_eos.html).
+- 'eos_l2_interfaces' should be used for preparing the node with L2 configurations, before applying L3 configurations using
+  this module (eos_l3_interfaces).
 options:
   config:
     description: A dictionary of Layer 3 interface options

--- a/plugins/modules/eos_l3_interfaces.py
+++ b/plugins/modules/eos_l3_interfaces.py
@@ -41,7 +41,7 @@ author: Nathaniel Case (@qalthos)
 notes:
 - Tested against Arista EOS 4.20.10M
 - This module works with connection C(network_cli). See the L(EOS Platform Options,../network/user_guide/platform_eos.html).
-  'eos_l2_interfaces' should be used for preparing the node with L2 configurations, before applying L3 configurations using
+  'eos_l2_interfaces/eos_interfaces' should be used for preparing the node , before applying L3 configurations using
   this module (eos_l3_interfaces).
 options:
   config:

--- a/plugins/modules/eos_l3_interfaces.py
+++ b/plugins/modules/eos_l3_interfaces.py
@@ -41,7 +41,7 @@ author: Nathaniel Case (@qalthos)
 notes:
 - Tested against Arista EOS 4.20.10M
 - This module works with connection C(network_cli). See the L(EOS Platform Options,../network/user_guide/platform_eos.html).
-- 'eos_l2_interfaces' should be used for preparing the node with L2 configurations, before applying L3 configurations using
+  'eos_l2_interfaces' should be used for preparing the node with L2 configurations, before applying L3 configurations using
   this module (eos_l3_interfaces).
 options:
   config:


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Targets #101 
eos_l2_interfaces should be used for preparing the node with L2 configs. This is explicitly mentioned in the eos_l3_interfaces RM documentaion.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
eos_l3_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
