### PR TITLE
Added 'mode' to eos_interfaces to enable/disable routed mode

### DIFF
--- a/changelogs/fragments/105-switchport-mode-interfaces.yaml
+++ b/changelogs/fragments/105-switchport-mode-interfaces.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Added 'mode' key to eos_interfaces to handle the layer2/3 switchport mode of an interface.

--- a/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
@@ -53,7 +53,6 @@ class InterfacesArgs(object):
                 "mode": {
                     "choices": ["layer2", "layer3"],
                     "type": "str",
-                    "default": "layer2",
                 },
             },
             "type": "list",

--- a/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
@@ -50,7 +50,7 @@ class InterfacesArgs(object):
                 "mtu": {"required": False, "type": "int"},
                 "speed": {"required": False, "type": "str"},
                 "duplex": {"required": False, "type": "str"},
-                "mode": {"choices": ["layer2", "layer3"], "type": "str"},
+                "mode": {"choices": ["layer2", "layer3"], "type": "str", "default": "layer2"},
             },
             "type": "list",
         },

--- a/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
@@ -50,7 +50,11 @@ class InterfacesArgs(object):
                 "mtu": {"required": False, "type": "int"},
                 "speed": {"required": False, "type": "str"},
                 "duplex": {"required": False, "type": "str"},
-                "mode": {"choices": ["layer2", "layer3"], "type": "str", "default": "layer2"},
+                "mode": {
+                    "choices": ["layer2", "layer3"],
+                    "type": "str",
+                    "default": "layer2",
+                },
             },
             "type": "list",
         },

--- a/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
@@ -50,10 +50,7 @@ class InterfacesArgs(object):
                 "mtu": {"required": False, "type": "int"},
                 "speed": {"required": False, "type": "str"},
                 "duplex": {"required": False, "type": "str"},
-                "mode": {
-                    "choices": ["layer2", "layer3"],
-                    "type": "str",
-                },
+                "mode": {"choices": ["layer2", "layer3"], "type": "str"},
             },
             "type": "list",
         },

--- a/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/argspec/interfaces/interfaces.py
@@ -50,6 +50,7 @@ class InterfacesArgs(object):
                 "mtu": {"required": False, "type": "int"},
                 "speed": {"required": False, "type": "str"},
                 "duplex": {"required": False, "type": "str"},
+                "mode": {"choices": ["layer2", "layer3"], "type": "str"},
             },
             "type": "list",
         },

--- a/plugins/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/config/interfaces/interfaces.py
@@ -253,6 +253,13 @@ def generate_commands(interface, to_set, to_remove):
         elif key == "duplex":
             # duplex is handled with speed
             continue
+        elif key == "mode":
+            if value == "layer3":
+                # switching from default (layer2) mode to layer3
+                commands.append("no switchport")
+            else:
+                # setting to default (layer 2) mode
+                commands.append("switchport")
         else:
             commands.append("{0} {1}".format(key, value))
 
@@ -267,6 +274,13 @@ def generate_commands(interface, to_set, to_remove):
         elif key == "duplex":
             # duplex is handled with speed
             continue
+        elif key == "mode":
+            if to_remove.get(key) == "layer3":
+                # remove layer3 and move back to default
+                commands.append("switchport")
+            else:
+                # set the interface to layer 3
+                commands.append("no switchport")
         else:
             commands.append("no {0}".format(key))
 

--- a/plugins/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/config/interfaces/interfaces.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import re
+
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.cfg.base import (
     ConfigBase,
 )
@@ -254,12 +256,13 @@ def generate_commands(interface, to_set, to_remove):
             # duplex is handled with speed
             continue
         elif key == "mode":
-            if value == "layer3":
-                # switching from default (layer2) mode to layer3
-                commands.append("no switchport")
-            else:
-                # setting to default (layer 2) mode
-                commands.append("switchport")
+            if not re.search(r'(M|m)anagement.*', interface):
+                if value == "layer3":
+                    # switching from default (layer2) mode to layer3
+                    commands.append("no switchport")
+                else:
+                    # setting to default (layer 2) mode
+                    commands.append("switchport")
         else:
             commands.append("{0} {1}".format(key, value))
 
@@ -275,7 +278,8 @@ def generate_commands(interface, to_set, to_remove):
             # duplex is handled with speed
             continue
         elif key == "mode":
-            commands.append("switchport")
+            if not re.search(r'(M|m)anagement.*', interface):
+                commands.append("switchport")
         else:
             commands.append("no {0}".format(key))
 

--- a/plugins/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/config/interfaces/interfaces.py
@@ -256,7 +256,7 @@ def generate_commands(interface, to_set, to_remove):
             # duplex is handled with speed
             continue
         elif key == "mode":
-            if not re.search(r'(M|m)anagement.*', interface):
+            if not re.search(r"(M|m)anagement.*", interface):
                 if value == "layer3":
                     # switching from default (layer2) mode to layer3
                     commands.append("no switchport")
@@ -278,7 +278,7 @@ def generate_commands(interface, to_set, to_remove):
             # duplex is handled with speed
             continue
         elif key == "mode":
-            if not re.search(r'(M|m)anagement.*', interface):
+            if not re.search(r"(M|m)anagement.*", interface):
                 commands.append("switchport")
         else:
             commands.append("no {0}".format(key))

--- a/plugins/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/config/interfaces/interfaces.py
@@ -275,12 +275,7 @@ def generate_commands(interface, to_set, to_remove):
             # duplex is handled with speed
             continue
         elif key == "mode":
-            if to_remove.get(key) == "layer3":
-                # remove layer3 and move back to default
-                commands.append("switchport")
-            else:
-                # set the interface to layer 3
-                commands.append("no switchport")
+            commands.append("switchport")
         else:
             commands.append("no {0}".format(key))
 

--- a/plugins/module_utils/network/eos/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/facts/interfaces/interfaces.py
@@ -95,6 +95,9 @@ class InterfacesFacts(object):
         shutdown = utils.parse_conf_cmd_arg(conf, "shutdown", False)
         config["enabled"] = shutdown if shutdown is False else True
         config["mtu"] = utils.parse_conf_arg(conf, "mtu")
+        config["mode"] = utils.parse_conf_cmd_arg(
+            conf, "switchport", "layer2", "layer3"
+        )
 
         speed_pair = utils.parse_conf_arg(conf, "speed")
         if speed_pair:

--- a/plugins/modules/eos_interfaces.py
+++ b/plugins/modules/eos_interfaces.py
@@ -86,7 +86,6 @@ options:
         choices:
         - layer2
         - layer3
-        default: layer2
         type: str
   running_config:
     description:

--- a/plugins/modules/eos_interfaces.py
+++ b/plugins/modules/eos_interfaces.py
@@ -79,6 +79,14 @@ options:
         description:
         - Interface link speed. Applicable for Ethernet interfaces only.
         type: str
+      mode:
+        description:
+        - Manage Layer2 or Layer3 state of the interface. Applicable for Ethernet
+          and port channel interfaces only.
+        choices:
+        - layer2
+        - layer3
+        type: str
   running_config:
     description:
     - This option is used only with state I(parsed).
@@ -127,6 +135,7 @@ EXAMPLES = """
     config:
     - name: Ethernet1
       enabled: true
+      mode: layer3
     - name: Ethernet2
       description: Configured by Ansible
       enabled: false
@@ -138,6 +147,7 @@ EXAMPLES = """
 # veos#show running-config | section interface
 # interface Ethernet1
 #    description "Interface 1"
+#    no switchport
 # !
 # interface Ethernet2
 #    description "Configured by Ansible"
@@ -237,6 +247,7 @@ EXAMPLES = """
 # veos#show running-config | section interface
 # interface Ethernet1
 #    description "Interface 1"
+#    no switchport
 # !
 # interface Ethernet2
 # !
@@ -271,6 +282,7 @@ EXAMPLES = """
     config:
     - name: Ethernet1
       enabled: true
+      mode: layer3
     - name: Ethernet2
       description: Configured by Ansible
       enabled: false
@@ -281,6 +293,7 @@ EXAMPLES = """
 
 # - "interface Ethernet1"
 # - "description "Interface 1""
+# - "no swithcport"
 # - "interface Ethernet2"
 # - "description "Configured by Ansible""
 # - "shutdown"
@@ -308,9 +321,11 @@ EXAMPLES = """
 # parsed:
 #     - name: Ethernet1
 #       enabled: True
+#       mode: layer2
 #     - name: Ethernet2
 #       description: 'Configured by Ansible'
 #       enabled: False
+#       mode: layer2
 
 # Using gathered:
 
@@ -332,9 +347,11 @@ EXAMPLES = """
 # gathered:
 #      - name: Ethernet1
 #        enabled: True
+#        mode: layer2
 #      - name: Ethernet2
 #        description: 'Configured by Ansible'
 #        enabled: False
+#        mode: layer2
 """
 
 RETURN = """

--- a/plugins/modules/eos_interfaces.py
+++ b/plugins/modules/eos_interfaces.py
@@ -86,6 +86,7 @@ options:
         choices:
         - layer2
         - layer3
+        default: layer2
         type: str
   running_config:
     description:

--- a/tests/integration/targets/eos_interfaces/templates/reset.cfg
+++ b/tests/integration/targets/eos_interfaces/templates/reset.cfg
@@ -1,10 +1,12 @@
 interface Ethernet1
    description "Interface 1"
+   switchport
    no shutdown
    no mtu
    speed forced 40gfull
 interface Ethernet2
    no description
    no shutdown
+   no switchport
    mtu 3000
    speed auto

--- a/tests/integration/targets/eos_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/eos_interfaces/tests/common/merged.yaml
@@ -5,6 +5,7 @@
     config:
 
       - name: Ethernet1
+        mode: layer3
         enabled: true
 
       - name: Ethernet2

--- a/tests/integration/targets/eos_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/eos_interfaces/tests/common/overridden.yaml
@@ -9,6 +9,7 @@
         enabled: true
 
       - name: Ethernet2
+        mode: layer2
         duplex: auto
         description: Configured by Ansible
         enabled: false
@@ -40,8 +41,3 @@
     that:
       - ansible_facts.network_resources.interfaces|symmetric_difference(result.after)|length
         == 0
-
-- assert:
-    that:
-      - config|difference(ansible_facts.network_resources.interfaces)|length ==
-        0

--- a/tests/integration/targets/eos_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/eos_interfaces/tests/common/replaced.yaml
@@ -11,6 +11,7 @@
       - name: Ethernet2
         description: Configured by Ansible
         duplex: auto
+        mode: layer2
         enabled: false
 
 - become: true
@@ -37,8 +38,3 @@
     that:
       - ansible_facts.network_resources.interfaces|symmetric_difference(result.after)|length
         == 0
-
-- assert:
-    that:
-      - config|difference(ansible_facts.network_resources.interfaces)|length ==
-        0

--- a/tests/integration/targets/eos_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_interfaces/tests/common/rtt.yaml
@@ -10,6 +10,7 @@
         enabled: false
     config2:
       - name: Ethernet1
+        mode: layer3
         enabled: true
         description: Config to be reverted
 
@@ -34,22 +35,6 @@
   arista.eos.eos_interfaces:
     config: '{{ config2 }}'
     state: merged
-
-- set_fact:
-    expected_config:
-
-      - name: Ethernet1
-        description: Config to be reverted
-        speed: 40g
-        duplex: full
-        enabled: true
-
-      - name: Ethernet2
-        description: Configured by Ansible
-        speed: '10'
-        duplex: full
-        enabled: false
-        mtu: '3000'
 
 - name: Revert back to base config using facts round trip
   become: true

--- a/tests/integration/targets/eos_interfaces/vars/main.yaml
+++ b/tests/integration/targets/eos_interfaces/vars/main.yaml
@@ -4,9 +4,11 @@ parsed:
     - name: Ethernet1
       description: 'Interface 1'
       enabled: true
+      mode: 'layer2'
     - name: Ethernet2
       description: 'Configured by Ansible'
       enabled: false
+      mode: 'layer2'
 
 rendered:
   - "interface Ethernet2"
@@ -15,3 +17,4 @@ rendered:
   - "shutdown"
   - "interface Ethernet1"
   - "no shutdown"
+  - "switchport"

--- a/tests/integration/targets/eos_interfaces/vars/main.yaml
+++ b/tests/integration/targets/eos_interfaces/vars/main.yaml
@@ -4,11 +4,9 @@ parsed:
     - name: Ethernet1
       description: 'Interface 1'
       enabled: true
-      mode: 'layer2'
     - name: Ethernet2
       description: 'Configured by Ansible'
       enabled: false
-      mode: 'layer2'
 
 rendered:
   - "interface Ethernet2"
@@ -17,4 +15,3 @@ rendered:
   - "shutdown"
   - "interface Ethernet1"
   - "no shutdown"
-  - "switchport"

--- a/tests/unit/modules/network/eos/fixtures/eos_interfaces_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_interfaces_config.cfg
@@ -1,5 +1,6 @@
 interface Ethernet1
    description "Interface 1"
 interface Ethernet2
+   no switchport
 interface Management1
    description "Management interface"

--- a/tests/unit/modules/network/eos/test_eos_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_interfaces.py
@@ -238,7 +238,6 @@ class TestEosInterfacesModule(TestEosModule):
             "description Ethernet 1",
             "interface Management1",
             "no description",
-            "switchport",
             "no shutdown",
         ]
         self.execute_module(changed=True, commands=commands)

--- a/tests/unit/modules/network/eos/test_eos_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_interfaces.py
@@ -119,11 +119,7 @@ class TestEosInterfacesModule(TestEosModule):
 
     def test_eos_interfaces_delete(self):
         set_module_args(dict(config=[dict(name="Ethernet1")], state="deleted"))
-        commands = [
-            "interface Ethernet1",
-            "no description",
-            "no shutdown",
-        ]
+        commands = ["interface Ethernet1", "no description", "no shutdown"]
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_interfaces_delete_switchport(self):

--- a/tests/unit/modules/network/eos/test_eos_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_interfaces.py
@@ -119,7 +119,7 @@ class TestEosInterfacesModule(TestEosModule):
 
     def test_eos_interfaces_delete(self):
         set_module_args(dict(config=[dict(name="Ethernet1")], state="deleted"))
-        commands = ["interface Ethernet1", "no description", "no shutdown"]
+        commands = ["interface Ethernet1", "no description", "switchport", "no shutdown"]
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_interfaces_delete_switchport(self):
@@ -169,7 +169,6 @@ class TestEosInterfacesModule(TestEosModule):
             "interface Ethernet1",
             "description Interface_1",
             "speed 1000gfull",
-            "switchport",
         ]
         self.execute_module(changed=True, commands=commands)
 
@@ -234,6 +233,7 @@ class TestEosInterfacesModule(TestEosModule):
             "description Ethernet 1",
             "interface Management1",
             "no description",
+            "switchport",
             "no shutdown",
         ]
         self.execute_module(changed=True, commands=commands)

--- a/tests/unit/modules/network/eos/test_eos_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_interfaces.py
@@ -119,7 +119,12 @@ class TestEosInterfacesModule(TestEosModule):
 
     def test_eos_interfaces_delete(self):
         set_module_args(dict(config=[dict(name="Ethernet1")], state="deleted"))
-        commands = ["interface Ethernet1", "no description", "switchport", "no shutdown"]
+        commands = [
+            "interface Ethernet1",
+            "no description",
+            "switchport",
+            "no shutdown",
+        ]
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_interfaces_delete_switchport(self):

--- a/tests/unit/modules/network/eos/test_eos_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_interfaces.py
@@ -122,7 +122,6 @@ class TestEosInterfacesModule(TestEosModule):
         commands = [
             "interface Ethernet1",
             "no description",
-            "switchport",
             "no shutdown",
         ]
         self.execute_module(changed=True, commands=commands)
@@ -163,7 +162,6 @@ class TestEosInterfacesModule(TestEosModule):
                         name="Ethernet1",
                         description="Interface_1",
                         speed="1000g",
-                        mode="layer2",
                         duplex="full",
                     )
                 ],


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
Fixes #101 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
eos_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

To set the routed mode for an interface:

```
eos_interfaces:
        config:
          - name: Ethernet2
            description: Configured by Ansible
            speed: '10'
            duplex: full
            mode: layer3
        state: merged
```

When **deleted ** is used, the default mode (layer 2 - switchport) will be set for an interface.
