### PR TITLE
eos_l2_interfaces: Added 'mode' to examples in documetation

### DIFF
--- a/changelogs/fragments/113-add-mode-to-examples.yaml
+++ b/changelogs/fragments/113-add-mode-to-examples.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added 'mode' to examples in documentation of eos_l2_interfaces.

--- a/plugins/modules/eos_l2_interfaces.py
+++ b/plugins/modules/eos_l2_interfaces.py
@@ -135,9 +135,11 @@ EXAMPLES = """
   arista.eos.eos_l2_interfaces:
     config:
     - name: Ethernet1
+      mode: trunk
       trunk:
         native_vlan: 10
     - name: Ethernet2
+      mode: access
       access:
         vlan: 30
     state: merged
@@ -180,6 +182,7 @@ EXAMPLES = """
   arista.eos.eos_l2_interfaces:
     config:
     - name: Ethernet1
+      mode: trunk
       trunk:
         native_vlan: 20
         trunk_vlans: 5-10, 15
@@ -226,6 +229,7 @@ EXAMPLES = """
   arista.eos.eos_l2_interfaces:
     config:
     - name: Ethernet2
+      mode: access
       access:
         vlan: 30
     state: overridden
@@ -287,9 +291,11 @@ EXAMPLES = """
   arista.eos.eos_l2_interfaces:
     config:
     - name: Ethernet1
+      mode: trunk
       trunk:
         native_vlan: 10
     - name: Ethernet2
+      mode: access
       access:
         vlan: 30
     state: merged
@@ -327,9 +333,11 @@ EXAMPLES = """
 # Output:
 #   parsed:
 #      - name: Ethernet1
+#        mode: trunk
 #        trunk:
 #          native_vlan: 10
 #      - name: Ethernet2
+#        mode: access
 #        access:
 #          vlan: 30
 
@@ -352,9 +360,11 @@ EXAMPLES = """
 # output:
 #   gathered:
 #      - name: Ethernet1
+#        mode: trunk
 #        trunk:
 #          native_vlan: 10
 #      - name: Ethernet2
+#        mode: access
 #        access:
 #          vlan: 30
 


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.c

##### SUMMARY
 The newly included 'mode' key is added to the examples.

Related to #112 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
eos_l2_interfaces.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
