### PR TITLE
eos_interfaces: Fix issue with 'forced' speed configuration.

### DIFF
--- a/changelogs/fragments/120-forcedspeed-interfaces-config.yaml
+++ b/changelogs/fragments/120-forcedspeed-interfaces-config.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - updated config dict, with duplex key when speed changes from 'x' to 'forced x' (https://github.com/ansible-collections/arista.eos/pull/120).

--- a/plugins/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/config/interfaces/interfaces.py
@@ -168,8 +168,11 @@ class Interfaces(ConfigBase):
             add_config = dict_diff(extant, desired)
             del_config = dict_diff(desired, extant)
 
-            if "speed" in add_config.keys() and "duplex" not in add_config.keys():
-                add_config.update({"duplex": desired.get('duplex')})
+            if (
+                "speed" in add_config.keys()
+                and "duplex" not in add_config.keys()
+            ):
+                add_config.update({"duplex": desired.get("duplex")})
 
             commands.extend(generate_commands(key, add_config, del_config))
 
@@ -193,8 +196,11 @@ class Interfaces(ConfigBase):
             add_config = dict_diff(extant, desired)
             del_config = dict_diff(desired, extant)
 
-            if "speed" in add_config.keys() and "duplex" not in add_config.keys():
-                add_config.update({"duplex": desired.get('duplex')})
+            if (
+                "speed" in add_config.keys()
+                and "duplex" not in add_config.keys()
+            ):
+                add_config.update({"duplex": desired.get("duplex")})
 
             commands.extend(generate_commands(key, add_config, del_config))
 
@@ -217,8 +223,11 @@ class Interfaces(ConfigBase):
                 extant = dict()
 
             add_config = dict_diff(extant, desired)
-            if "speed" in add_config.keys() and "duplex" not in add_config.keys():
-                add_config.update({"duplex": desired.get('duplex')})
+            if (
+                "speed" in add_config.keys()
+                and "duplex" not in add_config.keys()
+            ):
+                add_config.update({"duplex": desired.get("duplex")})
             commands.extend(generate_commands(key, add_config, {}))
 
         return commands

--- a/plugins/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/config/interfaces/interfaces.py
@@ -168,6 +168,9 @@ class Interfaces(ConfigBase):
             add_config = dict_diff(extant, desired)
             del_config = dict_diff(desired, extant)
 
+            if "speed" in add_config.keys() and "duplex" not in add_config.keys():
+                add_config.update({"duplex": desired.get('duplex')})
+
             commands.extend(generate_commands(key, add_config, del_config))
 
         return commands
@@ -190,6 +193,9 @@ class Interfaces(ConfigBase):
             add_config = dict_diff(extant, desired)
             del_config = dict_diff(desired, extant)
 
+            if "speed" in add_config.keys() and "duplex" not in add_config.keys():
+                add_config.update({"duplex": desired.get('duplex')})
+
             commands.extend(generate_commands(key, add_config, del_config))
 
         return commands
@@ -211,7 +217,8 @@ class Interfaces(ConfigBase):
                 extant = dict()
 
             add_config = dict_diff(extant, desired)
-
+            if "speed" in add_config.keys() and "duplex" not in add_config.keys():
+                add_config.update({"duplex": desired.get('duplex')})
             commands.extend(generate_commands(key, add_config, {}))
 
         return commands

--- a/plugins/module_utils/network/eos/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/facts/interfaces/interfaces.py
@@ -99,9 +99,8 @@ class InterfacesFacts(object):
             conf, "switchport", "layer2", "layer3"
         )
 
-        speed_pair = utils.parse_conf_arg(conf, "speed")
-        if speed_pair:
-            state = speed_pair
+        state = utils.parse_conf_arg(conf, "speed")
+        if state:
             if state == "auto":
                 config["duplex"] = state
             else:

--- a/plugins/module_utils/network/eos/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/facts/interfaces/interfaces.py
@@ -101,17 +101,11 @@ class InterfacesFacts(object):
 
         speed_pair = utils.parse_conf_arg(conf, "speed")
         if speed_pair:
-            state = speed_pair.split()
-            if state[0] == "forced":
-                state = state[1]
-            else:
-                state = state[0]
-
+            state = speed_pair
             if state == "auto":
                 config["duplex"] = state
             else:
                 # remaining options are all e.g., 10half or 40gfull
                 config["speed"] = state[:-4]
                 config["duplex"] = state[-4:]
-
         return utils.remove_empties(config)

--- a/tests/unit/modules/network/eos/fixtures/eos_interfaces_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_interfaces_config.cfg
@@ -1,6 +1,11 @@
 interface Ethernet1
    description "Interface 1"
 interface Ethernet2
+<<<<<<< HEAD
    no switchport
+=======
+interface Ethernet4
+   speed forced 10full
+>>>>>>> Added forced speed configuration
 interface Management1
    description "Management interface"

--- a/tests/unit/modules/network/eos/fixtures/eos_interfaces_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_interfaces_config.cfg
@@ -1,11 +1,8 @@
 interface Ethernet1
    description "Interface 1"
 interface Ethernet2
-<<<<<<< HEAD
    no switchport
-=======
 interface Ethernet4
-   speed forced 10full
->>>>>>> Added forced speed configuration
+  speed forced 10full
 interface Management1
    description "Management interface"

--- a/tests/unit/modules/network/eos/test_eos_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_interfaces.py
@@ -244,5 +244,8 @@ class TestEosInterfacesModule(TestEosModule):
             "interface Management1",
             "no description",
             "no shutdown",
+            "interface Ethernet4",
+            "speed auto",
+            "no shutdown",
         ]
         self.execute_module(changed=True, commands=commands)

--- a/tests/unit/modules/network/eos/test_eos_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_interfaces.py
@@ -100,6 +100,15 @@ class TestEosInterfacesModule(TestEosModule):
         )
         self.execute_module(changed=False, commands=[])
 
+    def test_eos_interfaces_merged_speed_idempotent(self):
+        set_module_args(
+            dict(
+                config=[dict(name="Ethernet4", speed="forced 10", duplex="full")],
+                state="merged",
+            )
+        )
+        self.execute_module(changed=False, commands=[])
+
     def test_eos_interfaces_replaced(self):
         set_module_args(
             dict(
@@ -235,19 +244,3 @@ class TestEosInterfacesModule(TestEosModule):
             "no shutdown",
         ]
         self.execute_module(changed=True, commands=commands)
-
-    # def test_eos_interfaces_overridden_idempotent(self):
-    #    set_module_args(dict(
-    #        config=[dict(
-    #            name="Ethernet1",
-    #            description="Interface 1"
-    #        ),
-    #        dict(
-    #        name="Ethernet2",
-    #        ),
-    #        dict(
-    #        name="Management 1",
-    #        description="Management interface"
-    #        )], state="overridden"
-    #    ))
-    #    self.execute_module(changed=False, commands=[])

--- a/tests/unit/modules/network/eos/test_eos_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_interfaces.py
@@ -103,7 +103,9 @@ class TestEosInterfacesModule(TestEosModule):
     def test_eos_interfaces_merged_speed_idempotent(self):
         set_module_args(
             dict(
-                config=[dict(name="Ethernet4", speed="forced 10", duplex="full")],
+                config=[
+                    dict(name="Ethernet4", speed="forced 10", duplex="full")
+                ],
                 state="merged",
             )
         )


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes : https://github.com/ansible-collections/arista.eos/issues/117

When speed configuration for the interface changes from `x` to `forced x` ,  the value for duplex is also passed to the `add_config` func (after necessary checks).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
eos_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
