### PR TITLE
Remove local connection testing for integration jobs

### DIFF
--- a/changelogs/fragments/127-drop-local-connection-testing.yaml
+++ b/changelogs/fragments/127-drop-local-connection-testing.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - stop integration testing of local connection as it is deprecated.

--- a/tests/integration/targets/eos_facts/tasks/cli.yaml
+++ b/tests/integration/targets/eos_facts/tasks/cli.yaml
@@ -15,10 +15,3 @@
   loop_control:
     loop_var: test_case_to_run
   tags: network_cli
-
-- name: run test cases (connection=local)
-  include: '{{ test_case_to_run }} ansible_connection=local'
-  with_items: '{{ test_items }}'
-  loop_control:
-    loop_var: test_case_to_run
-  tags: local

--- a/tests/integration/targets/eos_facts/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_facts/tasks/eapi.yaml
@@ -15,10 +15,3 @@
   loop_control:
     loop_var: test_case_to_run
   tags: httpapi
-
-- name: run test cases (connection=local)
-  include: '{{ test_case_to_run }} ansible_connection=local'
-  with_items: '{{ test_items }}'
-  loop_control:
-    loop_var: test_case_to_run
-  tags: local

--- a/tests/integration/targets/eos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/eos_smoke/tasks/cli.yaml
@@ -15,10 +15,3 @@
   loop_control:
     loop_var: test_case_to_run
   tags: network_cli
-
-- name: run test cases (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
-  with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run
-  tags: local

--- a/tests/integration/targets/eos_smoke/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_smoke/tasks/eapi.yaml
@@ -14,9 +14,3 @@
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local"
-  with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run


### PR DESCRIPTION
We no longer test local connection for integration tests.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>