### PR TITLE
Drop ansible from requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-ansible
 paramiko


### PR DESCRIPTION
Due to how ansible / ansible-base works now, this ends up messing up
ansible devel testing.  For now, remove the ansible dependency here
until we can create a fake ansible, with the right ansible-base
requirments.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>