### PR TITLE
Updates needed to start using execution environments

### DIFF
--- a/changelogs/fragments/requires-ansible.yaml
+++ b/changelogs/fragments/requires-ansible.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Uncap required ansible version in our collection.
+  - Fix yaml formatting errors in documentation.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.9.10,<2.11'
+requires_ansible: '>=2.9.10'
 plugin_routing:
   action:
     eos_acl_interfaces:

--- a/plugins/modules/eos_l3_interface.py
+++ b/plugins/modules/eos_l3_interface.py
@@ -111,14 +111,20 @@ EXAMPLES = """
 - name: Set IP addresses on aggregate
   arista.eos.eos_l3_interface:
     aggregate:
-    - {name: ethernet1, ipv4: 192.168.2.10/24}
-    - {name: ethernet1, ipv4: 192.168.3.10/24, ipv6: fd5d:12c9:2201:1::1/64}
+    - name: ethernet1
+      ipv4: 192.168.2.10/24
+    - name: ethernet1
+      ipv4: 192.168.3.10/24
+      ipv6: fd5d:12c9:2201:1::1/64
 
 - name: Remove IP addresses on aggregate
   arista.eos.eos_l3_interface:
     aggregate:
-    - {name: ethernet1, ipv4: 192.168.2.10/24}
-    - {name: ethernet1, ipv4: 192.168.3.10/24, ipv6: fd5d:12c9:2201:1::1/64}
+    - name: ethernet1
+      ipv4: 192.168.2.10/24
+    - name: ethernet1
+      ipv4: 192.168.3.10/24
+      ipv6: fd5d:12c9:2201:1::1/64
     state: absent
 """
 

--- a/plugins/modules/eos_vrf.py
+++ b/plugins/modules/eos_vrf.py
@@ -139,8 +139,10 @@ EXAMPLES = """
 - name: Create aggregate of VRFs with purge
   arista.eos.eos_vrf:
     aggregate:
-    - {name: test4, rd: 1:204}
-    - {name: test5, rd: 1:205}
+    - name: test4
+      rd: 1:204
+    - name: test5
+      rd: 1:205
     state: present
     purge: yes
 

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,0 +1,1 @@
+plugins/action/eos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`


### PR DESCRIPTION
This change starts the process of adding support for execution
environments for running sanity / unit tests.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/748
Depends-On: https://github.com/ansible/ansible/pull/73360
Signed-off-by: Paul Belanger <pabelanger@redhat.com>