### PR TITLE
Add support for single_user_mode

### DIFF
--- a/changelogs/fragments/single_user_mode.yaml
+++ b/changelogs/fragments/single_user_mode.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add support for configuration caching (single_user_mode).
+  - Re-use device_info dictionary in cliconf

--- a/plugins/terminal/eos.py
+++ b/plugins/terminal/eos.py
@@ -58,6 +58,8 @@ class TerminalModule(TerminalBase):
         ),
     ]
 
+    terminal_config_prompt = re.compile(r"^.+\(config(-.*)?\)#$")
+
     def on_open_shell(self):
         try:
             for cmd in (b"terminal length 0", b"terminal width 512"):

--- a/tests/integration/targets/eos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/eos_smoke/tasks/cli.yaml
@@ -15,3 +15,8 @@
   loop_control:
     loop_var: test_case_to_run
   tags: network_cli
+
+- name: run test cases with single_user_mode (connection=network_cli)
+  include: "{{ role_path }}/tests/cli/caching.yaml ansible_connection=network_cli ansible_network_single_user_mode=True ansible_connection=network_cli connection={{ cli }}"
+  tags:
+    - network_cli

--- a/tests/integration/targets/eos_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/eos_smoke/tests/cli/caching.yaml
@@ -9,6 +9,7 @@
 
   - name: Remove interfaces from config before actual testing
     ignore_errors: true
+    become: true
     arista.eos.eos_config: &rem
       lines:
         - no switchport mode trunk
@@ -25,6 +26,7 @@
 
   - name: Merge base interfaces configuration
     register: result
+    become: true
     arista.eos.eos_interfaces: &merged
       config:
         - name: Ethernet1
@@ -51,6 +53,7 @@
 
   - name: Merge base interfaces configuration (IDEMPOTENT)
     register: result
+    become: true
     arista.eos.eos_interfaces: *merged
 
   - assert:
@@ -59,6 +62,7 @@
 
   - name: Merge L2 interfaces configuration
     register: result
+    become: true
     arista.eos.eos_l2_interfaces: &mergedl2
       config:
         - name: Ethernet1
@@ -76,6 +80,7 @@
 
   - name: Merge L2 interfaces configuration (IDEMPOTENT)
     register: result
+    become: true
     arista.eos.eos_l2_interfaces: *mergedl2
 
   - assert:
@@ -84,6 +89,7 @@
 
   - name: Merge L3 interfaces configuration
     register: result
+    become: true
     arista.eos.eos_l3_interfaces: &mergedl3
       config:
         - name: Ethernet2
@@ -99,6 +105,7 @@
 
   - name: Merge L3 interfaces configuration (IDEMPOTENT)
     register: result
+    become: true
     arista.eos.eos_l3_interfaces: *mergedl3
 
   - assert:
@@ -107,6 +114,7 @@
 
   always:
     - name: cleanup
+      become: true
       arista.eos.eos_config: *rem
       with_items: "{{ interfaces }}"
       loop_control:

--- a/tests/integration/targets/eos_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/eos_smoke/tests/cli/caching.yaml
@@ -48,7 +48,7 @@
         - '"no switchport" in result.commands'
         - '"description Configured by Ansible" in result.commands'
         - '"no shutdown" in result.commands'
-        - result.commands|length == 8
+        - result.commands|length == 7
 
   - name: Merge base interfaces configuration (IDEMPOTENT)
     register: result

--- a/tests/integration/targets/eos_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/eos_smoke/tests/cli/caching.yaml
@@ -41,15 +41,14 @@
 
   - assert:
       that:
-        commands:
-          - '"interface Ethernet1" in result.commands'
-          - '"description Configured by Ansible" in result.commands'
-          - '"no shutdown" in result.commands'
-          - '"interface Ethernet2" in result.commands'
-          - '"no switchport" in result.commands'
-          - '"description Configured by Ansible" in result.commands'
-          - '"no shutdown" in result.commands'
-          - result.commands|length == 8
+        - '"interface Ethernet1" in result.commands'
+        - '"description Configured by Ansible" in result.commands'
+        - '"no shutdown" in result.commands'
+        - '"interface Ethernet2" in result.commands'
+        - '"no switchport" in result.commands'
+        - '"description Configured by Ansible" in result.commands'
+        - '"no shutdown" in result.commands'
+        - result.commands|length == 8
 
   - name: Merge base interfaces configuration (IDEMPOTENT)
     register: result

--- a/tests/integration/targets/eos_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/eos_smoke/tests/cli/caching.yaml
@@ -1,0 +1,114 @@
+---
+- block:
+  - debug: msg="START connection={{ ansible_connection }} cli/caching.yaml"
+
+  - set_fact:
+      interfaces:
+        - interface Ethernet1
+        - interface Ethernet2
+
+  - name: Remove interfaces from config before actual testing
+    ignore_errors: true
+    arista.eos.eos_config: &rem
+      lines:
+        - no switchport mode trunk
+        - no switchport trunk native vlan 10
+        - no description
+        - no ip address
+        - switchport
+        - shutdown
+        - no mtu
+      parents: "{{ intf }}"
+    with_items: "{{ interfaces }}"
+    loop_control:
+      loop_var: intf
+
+  - name: Merge base interfaces configuration
+    register: result
+    arista.eos.eos_interfaces: &merged
+      config:
+        - name: Ethernet1
+          description: Configured by Ansible
+          enabled: true
+
+        - name: Ethernet2
+          description: Configured by Ansible
+          mode: layer3
+          enabled: true
+      state: merged
+
+  - assert:
+      that:
+        commands:
+          - '"interface Ethernet1" in result.commands'
+          - '"description Configured by Ansible" in result.commands'
+          - '"no shutdown" in result.commands'
+          - '"interface Ethernet2" in result.commands'
+          - '"no switchport" in result.commands'
+          - '"description Configured by Ansible" in result.commands'
+          - '"no shutdown" in result.commands'
+          - result.commands|length == 8
+
+  - name: Merge base interfaces configuration (IDEMPOTENT)
+    register: result
+    arista.eos.eos_interfaces: *merged
+
+  - assert:
+      that:
+        - result.changed == False
+
+  - name: Merge L2 interfaces configuration
+    register: result
+    arista.eos.eos_l2_interfaces: &mergedl2
+      config:
+        - name: Ethernet1
+          mode: trunk
+          trunk:
+            native_vlan: 10
+      state: merged
+
+  - assert:
+      that:
+        - '"interface Ethernet1" in result.commands'
+        - '"switchport mode trunk" in result.commands'
+        - '"switchport trunk native vlan 10" in result.commands'
+        - result.commands|length == 3
+
+  - name: Merge L2 interfaces configuration (IDEMPOTENT)
+    register: result
+    arista.eos.eos_l2_interfaces: *mergedl2
+
+  - assert:
+      that:
+        - result.changed == False
+
+  - name: Merge L3 interfaces configuration
+    register: result
+    arista.eos.eos_l3_interfaces: &mergedl3
+      config:
+        - name: Ethernet2
+          ipv4:
+            - address: 203.0.113.227/31
+      state: merged
+
+  - assert:
+      that:
+        - '"interface Ethernet2" in result.commands'
+        - '"ip address 203.0.113.227/31" in result.commands'
+        - result.commands|length == 2
+
+  - name: Merge L3 interfaces configuration (IDEMPOTENT)
+    register: result
+    arista.eos.eos_l3_interfaces: *mergedl3
+
+  - assert:
+      that:
+        - result.changed == False
+
+  always:
+    - name: cleanup
+      arista.eos.eos_config: *rem
+      with_items: "{{ interfaces }}"
+      loop_control:
+        loop_var: intf
+  when: ansible_connection == "network_cli" and ansible_network_single_user_mode|d(False)


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/120
Depends-On: https://github.com/ansible-collections/arista.eos/pull/172

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Targets ansible-collections/ansible.netcommon#73
- Add support for ansible_single_user_mode option added in network_cli.
- Re-use device_info dictionary for every session.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cliconf/eos.py
terminal/eos.py