### PR TITLE
Move warning message for eos_config module

### DIFF
--- a/changelogs/fragments/config_module_warning_msg.yaml
+++ b/changelogs/fragments/config_module_warning_msg.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Move eos_config idempotent warning message with the task response under `warnings` key
+    if `changed` is `True`

--- a/plugins/modules/eos_config.py
+++ b/plugins/modules/eos_config.py
@@ -583,11 +583,15 @@ def main():
     ):
         msg = (
             "To ensure idempotency and correct diff the input configuration lines should be"
-            " similar to how they appear if present in the running configuration on device"
+            " similar to how they appear if present in"
+            " the running configuration on device"
         )
         if module.params["src"]:
             msg += " including the indentation"
-        warnings.append(msg)
+        if "warnings" in result:
+            result["warnings"].append(msg)
+        else:
+            result["warnings"] = msg
 
     module.exit_json(**result)
 

--- a/plugins/modules/eos_config.py
+++ b/plugins/modules/eos_config.py
@@ -446,14 +446,6 @@ def main():
             result["__backup__"] = contents
 
     if any((module.params["src"], module.params["lines"])):
-        msg = (
-            "To ensure idempotency and correct diff the input configuration lines should be"
-            " similar to how they appear if present in the running configuration on device"
-        )
-        if module.params["src"]:
-            msg += " including the indentation"
-        warnings.append(msg)
-
         match = module.params["match"]
         replace = module.params["replace"]
         path = module.params["parents"]
@@ -585,6 +577,17 @@ def main():
                         "diff": {"before": str(before), "after": str(after)},
                     }
                 )
+
+    if result.get("changed") and any(
+        (module.params["src"], module.params["lines"])
+    ):
+        msg = (
+            "To ensure idempotency and correct diff the input configuration lines should be"
+            " similar to how they appear if present in the running configuration on device"
+        )
+        if module.params["src"]:
+            msg += " including the indentation"
+        warnings.append(msg)
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Currently the warning message for diff is thrown
   for every module run.
*  Based on discussion here https://github.com/ansible/network/discussions/48
   a better way of logging the message is through verbose
   logs but verbose logging has a known issue https://github.com/ansible-collections/ansible.netcommon/issues/224
*  Hence moving the message under `warnings` key within the task
   response if `changed=True`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
