### PR TITLE
Fix galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 authors:
   - Ansible Network Community (ansible-network)
 dependencies:
-  "ansible.netcommon": "2.0.0"
+  "ansible.netcommon": ">=2.0.0"
 license_file: LICENSE
 name: eos
 description: Ansible Network Collection for Arista EOS devices.


### PR DESCRIPTION
##### SUMMARY
Zuul build in `ansible.netcommon` (here https://github.com/ansible-collections/ansible.netcommon/pull/227) fails with
```
Starting galaxy collection install process
Process install dependency map
ERROR! Cannot meet dependency requirement 'ansible.netcommon:2.0.0' for collection arista.eos from source 'ansible-netcommon-2.0.1-dev1.tar.gz'. Available versions before last requirement added: 2.0.1-dev1
Requirements from:
	base - 'ansible.netcommon:2.0.1-dev1'
	openvswitch.openvswitch - 'ansible.netcommon:*'
	junipernetworks.junos - 'ansible.netcommon:*'
	cisco.iosxr - 'ansible.netcommon:>=2.0.0'
	arista.eos - 'ansible.netcommon:2.0.0'
```
Looks like the changes should help

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request