### PR TITLE
Replace module._check_required_if with its implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ Name | Description
 --- | ---
 [arista.eos.eos](https://github.com/ansible-collections/arista.eos/blob/main/docs/arista.eos.eos_cliconf.rst)|Use eos cliconf to run command on Arista EOS platform
 
-### Filter plugins
-Name | Description
---- | ---
-
 ### Httpapi plugins
 Name | Description
 --- | ---
@@ -74,10 +70,6 @@ Name | Description
 [arista.eos.eos_vlan](https://github.com/ansible-collections/arista.eos/blob/main/docs/arista.eos.eos_vlan_module.rst)|(deprecated, removed after 2022-06-01) Manage VLANs on Arista EOS network devices
 [arista.eos.eos_vlans](https://github.com/ansible-collections/arista.eos/blob/main/docs/arista.eos.eos_vlans_module.rst)|VLANs resource module
 [arista.eos.eos_vrf](https://github.com/ansible-collections/arista.eos/blob/main/docs/arista.eos.eos_vrf_module.rst)|Manage VRFs on Arista EOS network devices
-
-### Inventory plugins
-Name | Description
---- | ---
 
 <!--end collection content-->
 

--- a/changelogs/fragments/183-check_required_if.yaml
+++ b/changelogs/fragments/183-check_required_if.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - switch required_if handling from module._check_required_if to validation.check_required_if as the former no longer exists in devel

--- a/docs/arista.eos.eos_acl_interfaces_module.rst
+++ b/docs/arista.eos.eos_acl_interfaces_module.rst
@@ -216,7 +216,7 @@ Parameters
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using Merged
 

--- a/docs/arista.eos.eos_acls_module.rst
+++ b/docs/arista.eos.eos_acls_module.rst
@@ -2839,7 +2839,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
 

--- a/docs/arista.eos.eos_banner_module.rst
+++ b/docs/arista.eos.eos_banner_module.rst
@@ -341,7 +341,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure the login banner
       arista.eos.eos_banner:

--- a/docs/arista.eos.eos_bgp_address_family_module.rst
+++ b/docs/arista.eos.eos_bgp_address_family_module.rst
@@ -974,7 +974,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
 

--- a/docs/arista.eos.eos_bgp_global_module.rst
+++ b/docs/arista.eos.eos_bgp_global_module.rst
@@ -7497,7 +7497,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     # Before state

--- a/docs/arista.eos.eos_bgp_module.rst
+++ b/docs/arista.eos.eos_bgp_module.rst
@@ -860,7 +860,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure global bgp as 64496
       arista.eos.eos_bgp:

--- a/docs/arista.eos.eos_command_module.rst
+++ b/docs/arista.eos.eos_command_module.rst
@@ -373,7 +373,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: run show version on remote devices
       arista.eos.eos_command:

--- a/docs/arista.eos.eos_config_module.rst
+++ b/docs/arista.eos.eos_config_module.rst
@@ -589,7 +589,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure top level settings
       arista.eos.eos_config:

--- a/docs/arista.eos.eos_eapi_module.rst
+++ b/docs/arista.eos.eos_eapi_module.rst
@@ -486,7 +486,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Enable eAPI access with default configuration
       arista.eos.eos_eapi:
@@ -568,7 +568,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>Hash of URL endpoints eAPI is listening on per interface</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AnsibleMapping([(&#x27;Management1&#x27;, [&#x27;http://172.26.10.1:80&#x27;])])</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;Management1&#x27;: [&#x27;http://172.26.10.1:80&#x27;]}</div>
                 </td>
             </tr>
     </table>

--- a/docs/arista.eos.eos_facts_module.rst
+++ b/docs/arista.eos.eos_facts_module.rst
@@ -319,7 +319,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Gather all legacy facts
     - arista.eos.eos_facts:

--- a/docs/arista.eos.eos_interface_module.rst
+++ b/docs/arista.eos.eos_interface_module.rst
@@ -724,7 +724,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure interface
       arista.eos.eos_interface:

--- a/docs/arista.eos.eos_interfaces_module.rst
+++ b/docs/arista.eos.eos_interfaces_module.rst
@@ -231,7 +231,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
 

--- a/docs/arista.eos.eos_l2_interface_module.rst
+++ b/docs/arista.eos.eos_l2_interface_module.rst
@@ -517,7 +517,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Ensure Ethernet1 does not have any switchport
       arista.eos.eos_l2_interface:

--- a/docs/arista.eos.eos_l2_interfaces_module.rst
+++ b/docs/arista.eos.eos_l2_interfaces_module.rst
@@ -231,7 +231,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
 

--- a/docs/arista.eos.eos_l3_interface_module.rst
+++ b/docs/arista.eos.eos_l3_interface_module.rst
@@ -444,7 +444,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Remove ethernet1 IPv4 and IPv6 address
       arista.eos.eos_l3_interface:

--- a/docs/arista.eos.eos_l3_interfaces_module.rst
+++ b/docs/arista.eos.eos_l3_interfaces_module.rst
@@ -236,7 +236,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using deleted
 

--- a/docs/arista.eos.eos_lacp_interfaces_module.rst
+++ b/docs/arista.eos.eos_lacp_interfaces_module.rst
@@ -159,7 +159,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/arista.eos.eos_lacp_module.rst
+++ b/docs/arista.eos.eos_lacp_module.rst
@@ -141,7 +141,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
 

--- a/docs/arista.eos.eos_lag_interfaces_module.rst
+++ b/docs/arista.eos.eos_lag_interfaces_module.rst
@@ -181,7 +181,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
 

--- a/docs/arista.eos.eos_linkagg_module.rst
+++ b/docs/arista.eos.eos_linkagg_module.rst
@@ -506,7 +506,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: create link aggregation group
       arista.eos.eos_linkagg:

--- a/docs/arista.eos.eos_lldp_global_module.rst
+++ b/docs/arista.eos.eos_lldp_global_module.rst
@@ -317,7 +317,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/arista.eos.eos_lldp_interfaces_module.rst
+++ b/docs/arista.eos.eos_lldp_interfaces_module.rst
@@ -163,7 +163,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/arista.eos.eos_lldp_module.rst
+++ b/docs/arista.eos.eos_lldp_module.rst
@@ -308,7 +308,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Enable LLDP service
       arista.eos.eos_lldp:

--- a/docs/arista.eos.eos_logging_module.rst
+++ b/docs/arista.eos.eos_logging_module.rst
@@ -534,7 +534,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure host logging
       arista.eos.eos_logging:

--- a/docs/arista.eos.eos_ospf_interfaces_module.rst
+++ b/docs/arista.eos.eos_ospf_interfaces_module.rst
@@ -1120,7 +1120,7 @@ Parameters
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
 

--- a/docs/arista.eos.eos_ospfv2_module.rst
+++ b/docs/arista.eos.eos_ospfv2_module.rst
@@ -2703,7 +2703,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
 

--- a/docs/arista.eos.eos_ospfv3_module.rst
+++ b/docs/arista.eos.eos_ospfv3_module.rst
@@ -3572,7 +3572,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
 

--- a/docs/arista.eos.eos_static_route_module.rst
+++ b/docs/arista.eos.eos_static_route_module.rst
@@ -480,7 +480,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure static route
       arista.eos.eos_static_route:

--- a/docs/arista.eos.eos_static_routes_module.rst
+++ b/docs/arista.eos.eos_static_routes_module.rst
@@ -405,7 +405,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using deleted
 

--- a/docs/arista.eos.eos_system_module.rst
+++ b/docs/arista.eos.eos_system_module.rst
@@ -385,7 +385,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure hostname and domain-name
       arista.eos.eos_system:

--- a/docs/arista.eos.eos_user_module.rst
+++ b/docs/arista.eos.eos_user_module.rst
@@ -596,7 +596,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: create a new user
       arista.eos.eos_user:

--- a/docs/arista.eos.eos_vlan_module.rst
+++ b/docs/arista.eos.eos_vlan_module.rst
@@ -535,7 +535,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Create vlan
       arista.eos.eos_vlan:

--- a/docs/arista.eos.eos_vlans_module.rst
+++ b/docs/arista.eos.eos_vlans_module.rst
@@ -160,7 +160,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using deleted
 

--- a/docs/arista.eos.eos_vrf_module.rst
+++ b/docs/arista.eos.eos_vrf_module.rst
@@ -524,7 +524,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Create vrf
       arista.eos.eos_vrf:

--- a/plugins/modules/eos_linkagg.py
+++ b/plugins/modules/eos_linkagg.py
@@ -158,7 +158,9 @@ commands:
 import re
 from copy import deepcopy
 
+from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.validation import check_required_together
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_default_spec,
 )
@@ -271,7 +273,10 @@ def map_params_to_obj(module, required_together=None):
                 if item.get(key) is None:
                     item[key] = module.params[key]
 
-            module._check_required_together(required_together, item)
+            try:
+                check_required_together(required_together, item)
+            except TypeError as exc:
+                module.fail_json(to_text(exc))
             d = item.copy()
             d["group"] = str(d["group"])
             d["min_links"] = str(d["min_links"])

--- a/plugins/modules/eos_logging.py
+++ b/plugins/modules/eos_logging.py
@@ -166,6 +166,7 @@ import re
 
 
 from copy import deepcopy
+from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.validation import check_required_if
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
@@ -412,7 +413,10 @@ def map_params_to_obj(module, required_if=None):
                 if item.get(key) is None:
                     item[key] = module.params[key]
 
-            check_required_if(required_if, item)
+            try:
+                check_required_if(required_if, item)
+            except TypeError as exc:
+                module.fail_json(to_text(exc))
             d = item.copy()
 
             if d["dest"] != "host":

--- a/plugins/modules/eos_logging.py
+++ b/plugins/modules/eos_logging.py
@@ -167,6 +167,7 @@ import re
 
 from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.validation import check_required_if
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_default_spec,
 )
@@ -411,7 +412,7 @@ def map_params_to_obj(module, required_if=None):
                 if item.get(key) is None:
                     item[key] = module.params[key]
 
-            module._check_required_if(required_if, item)
+            check_required_if(required_if, item)
             d = item.copy()
 
             if d["dest"] != "host":

--- a/plugins/modules/eos_static_route.py
+++ b/plugins/modules/eos_static_route.py
@@ -128,7 +128,9 @@ import re
 
 from copy import deepcopy
 
+from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.validation import check_required_together
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     is_masklen,
     validate_ip_address,
@@ -204,7 +206,10 @@ def map_params_to_obj(module, required_together=None):
                 if item.get(key) is None:
                     item[key] = module.params[key]
 
-            module._check_required_together(required_together, item)
+            try:
+                check_required_together(required_together, item)
+            except TypeError as exc:
+                module.fail_json(to_text(exc))
             d = item.copy()
 
             obj.append(d)

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -9,3 +9,7 @@ plugins/module_utils/network/eos/config/bgp_global/bgp_global.py import-2.6!skip
 plugins/module_utils/network/eos/config/bgp_address_family/bgp_address_family.py import-2.6!skip
 plugins/module_utils/network/eos/config/ospf_interfaces/ospf_interfaces.py import-2.6!skip
 plugins/module_utils/network/eos/config/ospfv3/ospfv3.py import-2.6!skip
+plugins/modules/eos_bgp_global.py validate-modules:no-log-needed # temporary workaround for unspecified no-log
+plugins/modules/eos_ospf_interfaces.py validate-modules:no-log-needed # temporary workaround for unspecified no-log
+plugins/modules/eos_ospfv3.py validate-modules:no-log-needed # temporary workaround for unspecified no-log
+plugins/modules/eos_user.py validate-modules:no-log-needed # temporary workaround for unspecified no-log


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
`_check_required_if` was just removed from AnsibleModule, so use the thing we probably should have been using all along

It is apparently now also a sanity issue to not specify a no_log value on potentially key-like arguments. I have added those as ignores for now, to deal with in a separate PR.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_logging
eos_linkagg
eos_static_route