### PR TITLE
Clean the setup before starting every integration test

### DIFF
--- a/changelogs/fragments/add_remove_config_integrationtests.yml
+++ b/changelogs/fragments/add_remove_config_integrationtests.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Add _remove_config before starting every integration test.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+ansible-pylibssh
 paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-ansible-pylibssh
 paramiko

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/deleted.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/deleted.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_address_family deleted integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - include_tasks: _populate.yaml
 
 - block:

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/gathered.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/gathered.yaml
@@ -3,6 +3,8 @@
     msg: START eos_bgp_address_family gathered integration tests on connection={{ ansible_connection
       }}
 
+- include_tasks: _remove_config.yaml
+
 - include_tasks: _populate.yaml
 
 - block:

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/merged.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/merged.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_address_family merged integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - block:
 
     - name: merge given bgp_address_family configuration

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/overridden.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/overridden.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_address_family overridden integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - include_tasks: _populate.yaml
 
 - block:

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/replaced.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/replaced.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_address_family replaced integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - include_tasks: _populate.yaml
 
 - block:

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/rtt.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_address_family rtt integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - block:
 
     - name: merge given bgp_address_family configuration

--- a/tests/integration/targets/eos_bgp_global/tests/common/deleted.yaml
+++ b/tests/integration/targets/eos_bgp_global/tests/common/deleted.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_global deleted integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - include_tasks: _populate.yaml
 
 - block:

--- a/tests/integration/targets/eos_bgp_global/tests/common/gathered.yaml
+++ b/tests/integration/targets/eos_bgp_global/tests/common/gathered.yaml
@@ -3,6 +3,8 @@
     msg: START eos_bgp_global gathered integration tests on connection={{ ansible_connection
       }}
 
+- include_tasks: _remove_config.yaml
+
 - include_tasks: _populate.yaml
 
 - block:

--- a/tests/integration/targets/eos_bgp_global/tests/common/merged.yaml
+++ b/tests/integration/targets/eos_bgp_global/tests/common/merged.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_global merged integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - block:
 
     - name: merge given bgp_global configuration

--- a/tests/integration/targets/eos_bgp_global/tests/common/purged.yaml
+++ b/tests/integration/targets/eos_bgp_global/tests/common/purged.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_global purged integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - include_tasks: _populate.yaml
 
 - block:

--- a/tests/integration/targets/eos_bgp_global/tests/common/replaced.yaml
+++ b/tests/integration/targets/eos_bgp_global/tests/common/replaced.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_global replaced integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - include_tasks: _populate.yaml
 
 - block:

--- a/tests/integration/targets/eos_bgp_global/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_bgp_global/tests/common/rtt.yaml
@@ -3,6 +3,8 @@
     msg: Start eos_bgp_global rtt integration tests ansible_connection={{
       ansible_connection }}
 
+- include_tasks: _remove_config.yaml
+
 - block:
 
     - name: merge given bgp_global configuration


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Few integration tests were failing because of some left over configs from the previous tests. Added _remove_config, before starting the tests, so that the setup is clean.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
