### PR TITLE
Skip vlan internal and vlan dynamic configs in vlan_facts

### DIFF
--- a/changelogs/fragments/vlan_id_alpha_configs.yml
+++ b/changelogs/fragments/vlan_id_alpha_configs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Skip when there are alpha values present following vlan keyword.

--- a/plugins/module_utils/network/eos/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/eos/facts/vlans/vlans.py
@@ -96,14 +96,16 @@ class VlansFacts(object):
         config = deepcopy(spec)
         vlans = []
 
-        vlan_list = vlan_to_list(utils.parse_conf_arg(conf, "vlan"))
-        for vlan in vlan_list:
-            config["vlan_id"] = vlan
-            config["name"] = utils.parse_conf_arg(conf, "name")
-            config["state"] = utils.parse_conf_arg(conf, "state")
-            if config["state"] is None:
-                config["state"] = "active"
-            vlans.append(utils.remove_empties(config))
+        parse_result = utils.parse_conf_arg(conf, "vlan")
+        if not parse_result.split(" ")[0].isalpha():
+            vlan_list = vlan_to_list(parse_result)
+            for vlan in vlan_list:
+                config["vlan_id"] = vlan
+                config["name"] = utils.parse_conf_arg(conf, "name")
+                config["state"] = utils.parse_conf_arg(conf, "state")
+                if config["state"] is None:
+                    config["state"] = "active"
+                vlans.append(utils.remove_empties(config))
 
         return vlans
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible-pylibssh >= 0.2.0
+ansible-pylibssh
 paramiko

--- a/tests/unit/modules/network/eos/fixtures/eos_vlan_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_vlan_config.cfg
@@ -1,2 +1,6 @@
 vlan_id 10
    name ten
+!
+vlan internal order ascending range 34 100
+!
+vlan dynamic range 23

--- a/tests/unit/modules/network/eos/test_eos_vlans.py
+++ b/tests/unit/modules/network/eos/test_eos_vlans.py
@@ -67,12 +67,14 @@ class TestEosVlansModule(TestEosModule):
     def load_fixtures(self, commands=None, transport="cli"):
         file_cmd = load_fixture("eos_vlan_config.cfg").split()
         file_cmd_dict = {}
-        for i in range(0, len(file_cmd), 2):
+        for i in range(0, len(file_cmd) - 2):
+            y = ""
             if file_cmd[i] == "vlan_id":
                 y = int(file_cmd[i + 1])
-            else:
+            elif file_cmd[i] in ["name", "state"]:
                 y = file_cmd[i + 1]
-            file_cmd_dict.update({file_cmd[i]: y})
+            if y:
+                file_cmd_dict.update({file_cmd[i]: y})
         self.execute_show_command.return_value = [file_cmd_dict]
 
     def test_eos_vlan_default(self):


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #191 

Skipping vlan_to_list func call, for "vlan internal" and "vlan dynamic" configurations.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
