### PR TITLE
eos_l3_interfaces: Normalize interface name in delete operation

### DIFF
--- a/changelogs/fragments/l3_interfaces_normalize_interface_name.yml
+++ b/changelogs/fragments/l3_interfaces_normalize_interface_name.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Normalize interface name before any operaion.

--- a/plugins/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
@@ -184,8 +184,9 @@ class L3_interfaces(ConfigBase):
         """
         commands = []
         for key, extant in have.items():
-            if key in want:
-                desired = want[key]
+            interface_name = normalize_interface(key)
+            if interface_name in want:
+                desired = want[interface_name]
             else:
                 desired = dict()
             if desired.get("ipv4"):
@@ -197,7 +198,7 @@ class L3_interfaces(ConfigBase):
             intf_commands.extend(clear_interface(desired, extant))
 
             if intf_commands:
-                commands.append("interface {0}".format(key))
+                commands.append("interface {0}".format(interface_name))
                 commands.extend(intf_commands)
 
         return commands
@@ -235,16 +236,17 @@ class L3_interfaces(ConfigBase):
         """
         commands = []
         for key in want:
+            interface_name = normalize_interface(key)
             desired = dict()
-            if key in have:
-                extant = have[key]
+            if interface_name in have:
+                extant = have[interface_name]
             else:
                 continue
 
             intf_commands = clear_interface(desired, extant)
 
             if intf_commands:
-                commands.append("interface {0}".format(key))
+                commands.append("interface {0}".format(interface_name))
                 commands.extend(intf_commands)
 
         return commands

--- a/tests/unit/modules/network/eos/fixtures/eos_l3_interfaces_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_l3_interfaces_config.cfg
@@ -11,3 +11,6 @@ interface Management1
 !
 interface Vlan100
   ip address virtual 192.13.45.12/24
+!
+interface Loopback99
+  ip address 1.1.1.1/24

--- a/tests/unit/modules/network/eos/test_eos_l3_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_l3_interfaces.py
@@ -149,6 +149,8 @@ class TestEosL3InterfacesModule(TestEosModule):
             "no ip address",
             "interface Vlan100",
             "no ip address",
+            "interface Loopback99",
+            "no ip address",
         ]
         self.execute_module(changed=True, commands=commands)
 
@@ -175,6 +177,7 @@ class TestEosL3InterfacesModule(TestEosModule):
                         name="Vlan100",
                         ipv4=[dict(address="192.13.45.12/24", virtual=True)],
                     ),
+                    dict(name="Loopback99", ipv4=[dict(address="1.1.1.1/24")]),
                 ],
                 state="overridden",
             )
@@ -223,6 +226,7 @@ class TestEosL3InterfacesModule(TestEosModule):
                         name="Vlan100",
                         ipv4=[dict(address="192.13.45.12/24", virtual=True)],
                     ),
+                    dict(name="Loopback99", ipv4=[dict(address="1.1.1.1/24")]),
                 ],
                 state="replaced",
             )
@@ -235,12 +239,18 @@ class TestEosL3InterfacesModule(TestEosModule):
                 config=[
                     dict(
                         name="Ethernet2", ipv6=[dict(address="2001:db8::1/64")]
-                    )
+                    ),
+                    dict(name="lo99", ipv4=[dict(address="1.1.1.1/24")]),
                 ],
                 state="deleted",
             )
         )
-        commands = ["interface Ethernet2", "no ipv6 address 2001:db8::1/64"]
+        commands = [
+            "interface Ethernet2",
+            "no ipv6 address 2001:db8::1/64",
+            "interface Loopback99",
+            "no ip address",
+        ]
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_l3_interfaces_rendered(self):
@@ -307,5 +317,6 @@ class TestEosL3InterfacesModule(TestEosModule):
                 "ipv4": [{"address": "192.13.45.12/24", "virtual": True}],
                 "name": "Vlan100",
             },
+            {"ipv4": [{"address": "1.1.1.1/24"}], "name": "Loopback99"},
         ]
         self.assertEqual(gather_list, result["gathered"])


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #193 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
eos_l3_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
