### PR TITLE
Support 'username sshkey' cli change in eos 4.23

### DIFF
--- a/changelogs/fragments/sshkey_cli_change.yaml
+++ b/changelogs/fragments/sshkey_cli_change.yaml
@@ -1,0 +1,3 @@
+---
+bugfix:
+  - Add support to accomodate change in username config cli in latest eos software version.

--- a/changelogs/fragments/sshkey_cli_change.yaml
+++ b/changelogs/fragments/sshkey_cli_change.yaml
@@ -1,3 +1,3 @@
 ---
-bugfix:
+bugfixes:
   - Add support to accomodate change in username config cli in latest eos software version.

--- a/plugins/modules/eos_user.py
+++ b/plugins/modules/eos_user.py
@@ -243,7 +243,8 @@ def get_os_version(module):
         r"Software image version:\s+([\d\.]+)", response[0], re.M
     )
     if version_match:
-        os_version = float(version_match.group(1))
+        v = version_match.group(1).split(".")
+        os_version = tuple(int(digit) for digit in v)
     return os_version
 
 
@@ -276,7 +277,8 @@ def map_obj_to_commands(updates, module):
 
         if needs_update("sshkey"):
             ver = get_os_version(module)
-            if ver > "4.20.10":
+            # compare against image version 4.20.10
+            if ver > (4, 20, 10):
                 add("ssh-key %s" % want["sshkey"])
             else:
                 add("sshkey %s" % want["sshkey"])

--- a/plugins/modules/eos_user.py
+++ b/plugins/modules/eos_user.py
@@ -243,7 +243,7 @@ def get_os_version(module):
         r"Software image version:\s+([\d\.]+)", response[0], re.M
     )
     if version_match:
-        os_version = version_match.group(1)
+        os_version = float(version_match.group(1))
     return os_version
 
 

--- a/plugins/modules/eos_user.py
+++ b/plugins/modules/eos_user.py
@@ -219,6 +219,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
     get_config,
     load_config,
+    run_commands,
 )
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
     eos_argument_spec,
@@ -231,6 +232,19 @@ def validate_privilege(value, module):
         module.fail_json(
             msg="privilege must be between 1 and 15, got %s" % value
         )
+
+
+def get_os_version(module):
+    os_version = "4.20.10"
+    response = run_commands(
+        module, 'show version | grep "Software image version"'
+    )
+    version_match = re.search(
+        r"Software image version:\s+([\d\.]+)", response[0], re.M
+    )
+    if version_match:
+        os_version = version_match.group(1)
+    return os_version
 
 
 def map_obj_to_commands(updates, module):
@@ -261,7 +275,11 @@ def map_obj_to_commands(updates, module):
             add("privilege %s" % want["privilege"])
 
         if needs_update("sshkey"):
-            add("sshkey %s" % want["sshkey"])
+            ver = get_os_version(module)
+            if ver > "4.20.10":
+                add("ssh-key %s" % want["sshkey"])
+            else:
+                add("sshkey %s" % want["sshkey"])
 
         if needs_update("nopassword"):
             if want["nopassword"]:
@@ -279,7 +297,6 @@ def map_obj_to_commands(updates, module):
                 module.fail_json(
                     msg="configured_password, sshkey or nopassword should be provided"
                 )
-
     return commands
 
 
@@ -290,7 +307,7 @@ def parse_role(data):
 
 
 def parse_sshkey(data):
-    match = re.search(r"sshkey (.+)$", data, re.M)
+    match = re.search(r"sshkey|ssh-key (.+)$", data, re.M)
     if match:
         return match.group(1)
 

--- a/tests/unit/modules/network/eos/test_eos_user.py
+++ b/tests/unit/modules/network/eos/test_eos_user.py
@@ -43,11 +43,18 @@ class TestEosUserModule(TestEosModule):
         )
         self.load_config = self.mock_load_config.start()
 
+        self.mock_get_os_version = patch(
+            "ansible_collections.arista.eos.plugins.modules.eos_user.get_os_version"
+        )
+        self.get_os_version = self.mock_get_os_version.start()
+        self.get_os_version.return_value = "4.20.10"
+
     def tearDown(self):
         super(TestEosUserModule, self).tearDown()
 
         self.mock_get_config.stop()
         self.mock_load_config.stop()
+        self.mock_get_os_version.stop()
 
     def load_fixtures(self, commands=None, transport="cli"):
         self.get_config.return_value = load_fixture("eos_user_config.cfg")
@@ -96,6 +103,12 @@ class TestEosUserModule(TestEosModule):
     def test_eos_user_sshkey(self):
         set_module_args(dict(name="ansible", sshkey="test"))
         commands = ["username ansible sshkey test"]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_eos_user_sshkey_4_23(self):
+        self.get_os_version.return_value = "4.23"
+        set_module_args(dict(name="ansible", sshkey="test"))
+        commands = ["username ansible ssh-key test"]
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_update_password_changed(self):

--- a/tests/unit/modules/network/eos/test_eos_user.py
+++ b/tests/unit/modules/network/eos/test_eos_user.py
@@ -47,7 +47,7 @@ class TestEosUserModule(TestEosModule):
             "ansible_collections.arista.eos.plugins.modules.eos_user.get_os_version"
         )
         self.get_os_version = self.mock_get_os_version.start()
-        self.get_os_version.return_value = "4.20.10"
+        self.get_os_version.return_value = (4, 20, 10)
 
     def tearDown(self):
         super(TestEosUserModule, self).tearDown()
@@ -106,7 +106,7 @@ class TestEosUserModule(TestEosModule):
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_sshkey_4_23(self):
-        self.get_os_version.return_value = "4.23"
+        self.get_os_version.return_value = (4, 23, 00)
         set_module_args(dict(name="ansible", sshkey="test"))
         commands = ["username ansible ssh-key test"]
         self.execute_module(changed=True, commands=commands)


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/885

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #189 
Cli changed from "username <name> sshkey" to "username <name> ssh-key".

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
