### PR TITLE
eos_eapi: Modify split pattern while getting the eapi interface and url

### DIFF
--- a/changelogs/fragments/split_eapi_url.yml
+++ b/changelogs/fragments/split_eapi_url.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Modify the split pattern while checking for eapi url in eos_eapi.

--- a/plugins/modules/eos_eapi.py
+++ b/plugins/modules/eos_eapi.py
@@ -382,7 +382,7 @@ def collect_facts(module, result):
     out = run_commands(module, ["show management api http-commands | json"])
     facts = dict(eos_eapi_urls=dict())
     for each in out[0]["urls"]:
-        intf, url = each.split(" : ")
+        intf, url = each.split(":", 1)
         key = str(intf).strip()
         if key not in facts["eos_eapi_urls"]:
             facts["eos_eapi_urls"][key] = list()

--- a/tests/unit/modules/network/eos/fixtures/eos_eapi_show_mgmt.json
+++ b/tests/unit/modules/network/eos/fixtures/eos_eapi_show_mgmt.json
@@ -32,6 +32,8 @@
     "urls": [
         "Management1 : https://172.26.4.24:443",
         "Management1 : http://172.26.4.24:80",
+        "Ethernet1: https://172.26.4.24:443",
+        "Ethernet1: http://172.26.4.24:80",
         "Unix Socket : unix:/var/run/command-api.sock",
         "Local       : http://localhost:8080/command-api"
     ],
@@ -44,4 +46,3 @@
     "commandCount": 59298,
     "bytesIn": 3189628
 }
-


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes: #174

The output always has a space before and after ':'. Since the submitter of the issue has reported otherwise, the split pattern has been made more generic.

The output from the device used for testing:

```URLs                                         
-------------------------------------------- 
Management1 : https://192.168.122.113:443    
Management1 : http://192.168.122.113:80      
Ethernet1   : https://[2001:db8:feed::1]:443 
Ethernet1   : http://[2001:db8:feed::1]:80   
Unix Socket : unix:/var/run/command-api.sock 

```
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
