### PR TITLE
Fix regex for password prompt

### DIFF
--- a/changelogs/fragments/fix_password_regex.yaml
+++ b/changelogs/fragments/fix_password_regex.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix regex for password prompt.

--- a/plugins/terminal/eos.py
+++ b/plugins/terminal/eos.py
@@ -74,7 +74,7 @@ class TerminalModule(TerminalBase):
         cmd = {u"command": u"enable"}
         if passwd:
             cmd[u"prompt"] = to_text(
-                r"[\r\n]?password: $", errors="surrogate_or_strict"
+                r"[\r\n]?[Pp]assword: $", errors="surrogate_or_strict"
             )
             cmd[u"answer"] = passwd
             cmd[u"prompt_retry_check"] = True


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Regex is modified to accept "password" and "Password".
Fixes #210 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
