### PR TITLE
eos_bgp_global: Add aliases to network and neighbor

### DIFF
--- a/changelogs/fragments/add_aliases.yml
+++ b/changelogs/fragments/add_aliases.yml
@@ -1,0 +1,3 @@
+---
+bug_fixes:
+  - Add alias to neighbor and network in bgp_global so that lists of objects are plural.

--- a/changelogs/fragments/add_aliases.yml
+++ b/changelogs/fragments/add_aliases.yml
@@ -1,3 +1,3 @@
 ---
-bug_fixes:
+bugfixes:
   - Add alias to neighbor and network in bgp_global so that lists of objects are plural.

--- a/docs/arista.eos.eos_bgp_global_module.rst
+++ b/docs/arista.eos.eos_bgp_global_module.rst
@@ -1607,6 +1607,7 @@ Parameters
                 </td>
                 <td>
                         <div>Configure routing for a network.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbors</div>
                 </td>
             </tr>
                                 <tr>
@@ -3143,6 +3144,7 @@ Parameters
                 </td>
                 <td>
                         <div>Configure routing for a network.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: networks</div>
                 </td>
             </tr>
                                 <tr>
@@ -5245,6 +5247,7 @@ Parameters
                 </td>
                 <td>
                         <div>Configure routing for a network.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: neighbors</div>
                 </td>
             </tr>
                                 <tr>
@@ -6861,6 +6864,7 @@ Parameters
                 </td>
                 <td>
                         <div>Configure routing for a network.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: networks</div>
                 </td>
             </tr>
                                 <tr>

--- a/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
@@ -259,6 +259,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                 "neighbor": {
                     "elements": "dict",
                     "type": "list",
+                    "aliases": ["neighbors"],
                     "options": {
                         "weight": {"type": "int"},
                         "default_originate": {
@@ -687,6 +688,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                         },
                         "neighbor": {
                             "elements": "dict",
+                            "aliases": ["neighbors"],
                             "type": "list",
                             "options": {
                                 "weight": {"type": "int"},
@@ -934,6 +936,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                         },
                         "network": {
                             "type": "list",
+                            "aliases": ["networks"],
                             "elements": "dict",
                             "options": {
                                 "route_map": {"type": "str"},
@@ -993,6 +996,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                 },
                 "network": {
                     "type": "list",
+                    "aliases": ["networks"],
                     "elements": "dict",
                     "options": {
                         "route_map": {"type": "str"},

--- a/plugins/modules/eos_bgp_global.py
+++ b/plugins/modules/eos_bgp_global.py
@@ -596,6 +596,8 @@ options:
             weight:
               description: Weight to assign.
               type: int
+          aliases:
+            - neighbors
         network:
           description: Configure routing for a network.
           type: list
@@ -607,6 +609,8 @@ options:
             route_map:
               description: Name of route map.
               type: str
+          aliases:
+            - networks
         redistribute:
           description: Redistribute routes in to BGP.
           type: list
@@ -969,6 +973,8 @@ options:
                   type: int
             neighbor:
               description: Configure routing for a network.
+              aliases:
+                - neighbors
               type: list
               elements: dict
               suboptions:
@@ -1246,6 +1252,8 @@ options:
                   type: int
             network:
               description: Configure routing for a network.
+              aliases:
+                - networks
               type: list
               elements: dict
               suboptions:

--- a/tests/unit/modules/network/eos/test_eos_bgp_global.py
+++ b/tests/unit/modules/network/eos/test_eos_bgp_global.py
@@ -144,7 +144,7 @@ class TestEosBgpglobalModule(TestEosModule):
                                     mode="update_delay", update_delay=10
                                 )
                             ),
-                            neighbor=[
+                            neighbors=[
                                 dict(
                                     peer="peer1",
                                     peer_group="peer1",
@@ -170,7 +170,7 @@ class TestEosBgpglobalModule(TestEosModule):
                         )
                     ],
                     default_metric=433,
-                    network=[
+                    networks=[
                         dict(address="6.6.6.0/24", route_map="netmap1"),
                         dict(address="10.1.0.0/16"),
                     ],


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Added aliases (neighbors and networks) to neighbor and network, since lists of objects, should be plural.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
