### PR TITLE
Don't rely on `safe_eval` being able to do math/concat

### DIFF
--- a/changelogs/fragments/225-safe-eval-no-concat.yml
+++ b/changelogs/fragments/225-safe-eval-no-concat.yml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - Don't rely on ``safe_eval`` being able to do math/concat
+    (https://github.com/ansible-collections/arista.eos/pull/225)

--- a/tests/integration/targets/eos_acl_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/eos_acl_interfaces/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_acl_interfaces/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_acl_interfaces/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_acls/tasks/cli.yaml
+++ b/tests/integration/targets/eos_acls/tasks/cli.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_acls/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_acls/tasks/eapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_bgp_address_family/tasks/cli.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_bgp_address_family/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_bgp_global/tasks/cli.yaml
+++ b/tests/integration/targets/eos_bgp_global/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_bgp_global/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_bgp_global/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/eos_interfaces/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_interfaces/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_interfaces/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_l2_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/eos_l2_interfaces/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_l2_interfaces/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_l2_interfaces/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_l3_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_l3_interfaces/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tasks/eapi.yaml
@@ -16,7 +16,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_l3_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tests/common/deleted.yaml
@@ -41,7 +41,7 @@
   become: true
 
 - set_fact:
-    expected_config: '{{ config }} + {{ other_config }}'
+    expected_config: '{{ config + other_config }}'
 
 - assert:
     that:

--- a/tests/integration/targets/eos_l3_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tests/common/replaced.yaml
@@ -50,7 +50,7 @@
   become: true
 
 - set_fact:
-    expected_config: '{{ config }} + {{ other_config }}'
+    expected_config: '{{ config + other_config }}'
 
 - assert:
     that:

--- a/tests/integration/targets/eos_lacp/tasks/cli.yaml
+++ b/tests/integration/targets/eos_lacp/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lacp/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_lacp/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lacp_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lacp_interfaces/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lacp_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tests/common/replaced.yaml
@@ -38,7 +38,7 @@
         == []
 
 - set_fact:
-    expected_config: '{{ config }} + {{ other_config }}'
+    expected_config: '{{ config + other_config }}'
 
 - assert:
     that:

--- a/tests/integration/targets/eos_lag_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/eos_lag_interfaces/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lag_interfaces/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_lag_interfaces/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lag_interfaces/tests/cli/replaced.yaml
+++ b/tests/integration/targets/eos_lag_interfaces/tests/cli/replaced.yaml
@@ -43,7 +43,7 @@
         == 0
 
 - set_fact:
-    expected_config: '{{ config }} + {{ other_config }}'
+    expected_config: '{{ config + other_config }}'
 
 - assert:
     that:

--- a/tests/integration/targets/eos_lldp_global/tasks/cli.yaml
+++ b/tests/integration/targets/eos_lldp_global/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lldp_global/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_lldp_global/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lldp_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/eos_lldp_interfaces/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lldp_interfaces/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_lldp_interfaces/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_lldp_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/eos_lldp_interfaces/tests/common/replaced.yaml
@@ -38,7 +38,7 @@
         == []
 
 - set_fact:
-    expected_config: '{{ config }} + {{ other_config }}'
+    expected_config: '{{ config + other_config }}'
 
 - assert:
     that:

--- a/tests/integration/targets/eos_ospf_interfaces/tasks/cli.yaml
+++ b/tests/integration/targets/eos_ospf_interfaces/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_ospf_interfaces/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_ospf_interfaces/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_ospfv2/tasks/cli.yaml
+++ b/tests/integration/targets/eos_ospfv2/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_ospfv2/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_ospfv2/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_ospfv3/tasks/cli.yaml
+++ b/tests/integration/targets/eos_ospfv3/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_ospfv3/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_ospfv3/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_prefix_lists/tasks/cli.yaml
+++ b/tests/integration/targets/eos_prefix_lists/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_prefix_lists/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_prefix_lists/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_route_maps/tasks/cli.yaml
+++ b/tests/integration/targets/eos_route_maps/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_route_maps/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_route_maps/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_static_routes/tasks/cli.yaml
+++ b/tests/integration/targets/eos_static_routes/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_static_routes/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_static_routes/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_vlans/tasks/cli.yaml
+++ b/tests/integration/targets/eos_vlans/tasks/cli.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ cli_cases.files }}'
+      files: '{{ test_cases.files + cli_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_vlans/tasks/eapi.yaml
+++ b/tests/integration/targets/eos_vlans/tasks/eapi.yaml
@@ -17,7 +17,7 @@
 
 - set_fact:
     test_cases:
-      files: '{{ test_cases.files }} + {{ eapi_cases.files }}'
+      files: '{{ test_cases.files + eapi_cases.files }}'
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/tests/integration/targets/eos_vlans/tests/common/replaced.yaml
+++ b/tests/integration/targets/eos_vlans/tests/common/replaced.yaml
@@ -39,7 +39,7 @@
         == []
 
 - set_fact:
-    expected_config: '{{ config }} + {{ other_config }}'
+    expected_config: '{{ config + other_config }}'
 
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
Don't rely on `safe_eval` being able to do math/concat. This functionality will be removed in ansible-core 2.12, and has never worked with jinja2 native which we are working toward making the default in 2.12.

See https://github.com/ansible/ansible/pull/75068

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
