### PR TITLE
Fix ospf3 to be ospfv3

### DIFF
--- a/changelogs/fragments/bgp_cli_change.yaml
+++ b/changelogs/fragments/bgp_cli_change.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Fix ospf3 to be ospfv3 in bgp config.

--- a/plugins/module_utils/network/eos/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_address_family/bgp_address_family.py
@@ -83,7 +83,7 @@ class Bgp_afArgs(object):  # pylint: disable=R0903
                                 "route_map": {"type": "str"},
                                 "protocol": {
                                     "type": "str",
-                                    "choices": ["isis", "ospf3", "dhcp"],
+                                    "choices": ["isis", "ospfv3", "dhcp"],
                                 },
                                 "isis_level": {
                                     "type": "str",

--- a/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
@@ -74,7 +74,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                             "type": "str",
                             "choices": [
                                 "isis",
-                                "ospf3",
+                                "ospfv3",
                                 "ospf",
                                 "attached-host",
                                 "connected",
@@ -495,7 +495,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                     "type": "str",
                                     "choices": [
                                         "isis",
-                                        "ospf3",
+                                        "ospfv3",
                                         "ospf",
                                         "attached-host",
                                         "connected",

--- a/plugins/module_utils/network/eos/providers/cli/config/bgp/process.py
+++ b/plugins/module_utils/network/eos/providers/cli/config/bgp/process.py
@@ -25,7 +25,7 @@ from ansible_collections.arista.eos.plugins.module_utils.network.eos.providers.c
 )
 
 REDISTRIBUTE_PROTOCOLS = frozenset(
-    ["ospf", "ospf3", "rip", "isis", "static", "connected"]
+    ["ospf", "ospfv3", "rip", "isis", "static", "connected"]
 )
 
 

--- a/plugins/modules/eos_bgp.py
+++ b/plugins/modules/eos_bgp.py
@@ -129,7 +129,7 @@ options:
             - Specifies the protocol for configuring redistribute information.
             required: true
             type: str
-            choices: [ospf, ospf3, static, connected, rip, isis]
+            choices: [ospf, ospfv3, static, connected, rip, isis]
           route_map:
             description:
             - Specifies the route map reference.
@@ -183,7 +183,7 @@ options:
                 required: true
                 type: str
                 choices:
-                - ospf3
+                - ospfv3
                 - ospf
                 - isis
                 - static

--- a/plugins/modules/eos_bgp_address_family.py
+++ b/plugins/modules/eos_bgp_address_family.py
@@ -177,7 +177,7 @@ options:
                 protocol:
                   description: Routes to be redistributed.
                   type: str
-                  choices: ['isis', 'ospf3', 'dhcp']
+                  choices: ['isis', 'ospfv3', 'dhcp']
                 route_map:
                   description: Route map reference.
                   type: str
@@ -237,7 +237,7 @@ EXAMPLES = """
         address_family:
           - afi: "ipv4"
             redistribute:
-              - protocol: "ospf3"
+              - protocol: "ospfv3"
                 ospf_route: "external"
             network:
               - address: "1.1.1.0/24"
@@ -272,7 +272,7 @@ EXAMPLES = """
 #       neighbor 1.1.1.1 activate
 #       network 1.1.1.0/24
 #       network 1.5.1.0/24 route-map MAP01
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    address-family ipv6
 #       bgp additional-paths receive
@@ -294,7 +294,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -334,7 +334,7 @@ EXAMPLES = """
 #     "commands": [
 #         "router bgp 10",
 #         "address-family ipv4",
-#         "redistribute ospf3 match external",
+#         "redistribute ospfv3 match external",
 #         "network 1.1.1.0/24",
 #         "network 1.5.1.0/24 route-map MAP01",
 #         "exit",
@@ -364,7 +364,7 @@ EXAMPLES = """
 #       neighbor 1.1.1.1 activate
 #       network 1.1.1.0/24
 #       network 1.5.1.0/24 route-map MAP01
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    address-family ipv6
 #       bgp additional-paths receive
@@ -386,7 +386,7 @@ EXAMPLES = """
           - afi: "ipv6"
             vrf: "vrft"
             redistribute:
-              - protocol: "ospf3"
+              - protocol: "ospfv3"
                 ospf_route: "external"
           - afi: "ipv6"
             redistribute:
@@ -406,7 +406,7 @@ EXAMPLES = """
 #       neighbor 1.1.1.1 activate
 #       network 1.1.1.0/24
 #       network 1.5.1.0/24 route-map MAP01
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    address-family ipv6
 #       neighbor peer2 default-originate always
@@ -414,7 +414,7 @@ EXAMPLES = """
 #    !
 #    vrf vrft
 #       address-family ipv6
-#          redistribute ospf3 match external
+#          redistribute ospfv3 match external
 # veos(config-router-bgp)#
 #
 #
@@ -442,7 +442,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -468,7 +468,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ],
 #                 "vrf": "vrft"
@@ -498,7 +498,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -539,7 +539,7 @@ EXAMPLES = """
 #         "router bgp 10",
 #         "vrf vrft",
 #         "address-family ipv6",
-#         "redistribute ospf3 match external",
+#         "redistribute ospfv3 match external",
 #         "no redistribute isis level-2",
 #         "no route-target export 33:11",
 #         "exit",
@@ -564,7 +564,7 @@ EXAMPLES = """
 #       neighbor 1.1.1.1 activate
 #       network 1.1.1.0/24
 #       network 1.5.1.0/24 route-map MAP01
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    address-family ipv6
 #       neighbor peer2 default-originate always
@@ -572,7 +572,7 @@ EXAMPLES = """
 #    !
 #    vrf vrft
 #       address-family ipv6
-#          redistribute ospf3 match external
+#          redistribute ospfv3 match external
 # veos(config-router-bgp)#
 
   - name: Overridden
@@ -602,7 +602,7 @@ EXAMPLES = """
 #    !
 #    vrf vrft
 #       address-family ipv6
-#          redistribute ospf3 match external
+#          redistribute ospfv3 match external
 # veos(config-router-bgp)#
 #
 # Module Execution:
@@ -628,7 +628,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ],
 #                 "vrf": "vrft"
@@ -658,7 +658,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -684,7 +684,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ],
 #                 "vrf": "vrft"
@@ -696,7 +696,7 @@ EXAMPLES = """
 #     "commands": [
 #         "router bgp 10",
 #         "address-family ipv4",
-#         "no redistribute ospf3 match external",
+#         "no redistribute ospfv3 match external",
 #         "no network 1.1.1.0/24",
 #         "no network 1.5.1.0/24 route-map MAP01",
 #         "neighbor peer2 default-originate always",
@@ -722,7 +722,7 @@ EXAMPLES = """
 #       no neighbor 1.1.1.1 activate
 #       network 1.1.1.0/24
 #       network 1.5.1.0/24 route-map MAP01
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    address-family ipv6
 #       bgp additional-paths receive
@@ -732,7 +732,7 @@ EXAMPLES = """
 #       address-family ipv6
 #          route-target export 33:11
 #          redistribute isis level-2
-#          redistribute ospf3 match external
+#          redistribute ospfv3 match external
 # veos(config-router-bgp)#
 
 
@@ -764,7 +764,7 @@ EXAMPLES = """
 #       neighbor peer2 default-originate always
 #       network 1.1.1.0/24
 #       network 1.5.1.0/24 route-map MAP01
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    address-family ipv6
 #       bgp additional-paths receive
@@ -804,7 +804,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -859,7 +859,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -886,7 +886,7 @@ EXAMPLES = """
 #                     },
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ],
 #                 "route_target": {
@@ -925,7 +925,7 @@ EXAMPLES = """
 #       no neighbor 1.1.1.1 activate
 #       network 1.1.1.0/24
 #       network 1.5.1.0/24 route-map MAP01
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    address-family ipv6
 #       bgp additional-paths receive
@@ -960,7 +960,7 @@ EXAMPLES = """
 #       no neighbor 1.1.1.1 activate
 #       network 1.1.1.0/24
 #       network 1.5.1.0/24 route-map MAP01
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    vrf vrft
 #       address-family ipv4
@@ -996,7 +996,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -1037,7 +1037,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -1082,7 +1082,7 @@ EXAMPLES = """
 #    address-family ipv4
 #       bgp additional-paths receive
 #       neighbor peer2 default-originate always
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    address-family ipv6
 #       no bgp additional-paths receive
@@ -1101,7 +1101,7 @@ EXAMPLES = """
 #          bgp additional-paths receive
 #       !
 #       address-family ipv6
-#          redistribute ospf3 match external
+#          redistribute ospfv3 match external
 
   - name: parse configs
     arista.eos.eos_bgp_address_family:
@@ -1127,7 +1127,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -1166,7 +1166,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ],
 #                 "vrf": "vrft"
@@ -1191,7 +1191,7 @@ EXAMPLES = """
 #       no neighbor 1.1.1.1 activate
 #       network 1.1.1.0/24
 #       network 1.5.1.0/24 route-map MAP01
-#       redistribute ospf3 match external
+#       redistribute ospfv3 match external
 #    !
 #    vrf vrft
 #       address-family ipv4
@@ -1230,7 +1230,7 @@ EXAMPLES = """
 #                 "redistribute": [
 #                     {
 #                         "ospf_route": "external",
-#                         "protocol": "ospf3"
+#                         "protocol": "ospfv3"
 #                     }
 #                 ]
 #             },
@@ -1254,7 +1254,7 @@ EXAMPLES = """
         address_family:
           - afi: "ipv4"
             redistribute:
-              - protocol: "ospf3"
+              - protocol: "ospfv3"
                 ospf_route: "external"
             network:
               - address: "1.1.1.0/24"
@@ -1283,7 +1283,7 @@ EXAMPLES = """
 # "rendered": [
 #         "router bgp 10",
 #         "address-family ipv4",
-#         "redistribute ospf3 match external",
+#         "redistribute ospfv3 match external",
 #         "network 1.1.1.0/24",
 #         "network 1.5.1.0/24 route-map MAP01",
 #         "exit",

--- a/plugins/modules/eos_bgp_global.py
+++ b/plugins/modules/eos_bgp_global.py
@@ -619,7 +619,7 @@ options:
             protocol:
               description: Routes to be redistributed.
               type: str
-              choices: ['isis', 'ospf3', 'ospf', 'attached-host', 'connected', 'rip', 'static']
+              choices: ['isis', 'ospfv3', 'ospf', 'attached-host', 'connected', 'rip', 'static']
             route_map:
               description: Route map reference.
               type: str
@@ -1271,7 +1271,7 @@ options:
                 protocol:
                   description: Routes to be redistributed.
                   type: str
-                  choices: ['isis', 'ospf3', 'ospf', 'attached-host', 'connected', 'rip', 'static']
+                  choices: ['isis', 'ospfv3', 'ospf', 'attached-host', 'connected', 'rip', 'static']
                 route_map:
                   description: Route map reference.
                   type: str

--- a/tests/integration/targets/eos_bgp_address_family/defaults/main.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: ''
+testcase: '[^_].*'
 test_items: []

--- a/tests/integration/targets/eos_bgp_address_family/defaults/main.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '[^_].*'
+testcase: ''
 test_items: []

--- a/tests/integration/targets/eos_bgp_address_family/templates/populate.cfg
+++ b/tests/integration/targets/eos_bgp_address_family/templates/populate.cfg
@@ -13,7 +13,7 @@ router bgp 65536
       neighbor 192.0.2.1 activate
       network 192.0.2.0/24
       network 203.0.113.0/24 route-map MAP01
-      redistribute ospf3 match external
+      redistribute ospfv3 match external
    !
    vrf vrft
       address-family ipv4

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/_parsed.cfg
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/_parsed.cfg
@@ -13,7 +13,7 @@ router bgp 65536
       neighbor 192.0.2.1 activate
       network 192.0.2.0/24
       network 203.0.113.0/24 route-map MAP01
-      redistribute ospf3 match external
+      redistribute ospfv3 match external
    !
    vrf vrft
       address-family ipv4

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/_redirection.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/_redirection.yaml
@@ -16,7 +16,7 @@
           address_family:
             - afi: "ipv4"
               redistribute:
-                - protocol: "ospf3"
+                - protocol: "ospfv3"
                   ospf_route: "external"
               network:
                 - address: "192.0.2.0/24"

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/merged.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/merged.yaml
@@ -16,7 +16,7 @@
           address_family:
             - afi: "ipv4"
               redistribute:
-                - protocol: "ospf3"
+                - protocol: "ospfv3"
                   ospf_route: "external"
               network:
                 - address: "192.0.2.0/24"

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/overridden.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/overridden.yaml
@@ -20,7 +20,7 @@
             - afi: "ipv4"
               vrf: "vrft"
               redistribute:
-                - protocol: "ospf3"
+                - protocol: "ospfv3"
                   ospf_route: "external"
               bgp_params:
                 additional_paths: "receive"

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/rendered.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/rendered.yaml
@@ -15,7 +15,7 @@
           address_family:
             - afi: "ipv4"
               redistribute:
-                - protocol: "ospf3"
+                - protocol: "ospfv3"
                   ospf_route: "external"
               network:
                 - address: "192.0.2.0/24"

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/replaced.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/replaced.yaml
@@ -20,7 +20,7 @@
             - afi: "ipv4"
               vrf: "vrft"
               redistribute:
-                - protocol: "ospf3"
+                - protocol: "ospfv3"
                   ospf_route: "external"
               bgp_params:
                 additional_paths: "receive"

--- a/tests/integration/targets/eos_bgp_address_family/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tests/common/rtt.yaml
@@ -16,7 +16,7 @@
           address_family:
             - afi: "ipv4"
               redistribute:
-                - protocol: "ospf3"
+                - protocol: "ospfv3"
                   ospf_route: "external"
               network:
                 - address: "192.0.2.0/24"
@@ -62,7 +62,7 @@
             - afi: "ipv6"
               vrf: "vrft"
               redistribute:
-                - protocol: "ospf3"
+                - protocol: "ospfv3"
                   ospf_route: "external"
             - afi: "evpn"
               graceful_restart: true

--- a/tests/integration/targets/eos_bgp_address_family/vars/main.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/vars/main.yaml
@@ -3,7 +3,7 @@ merged:
   commands:
     - router bgp 65536
     - address-family ipv4
-    - redistribute ospf3 match external
+    - redistribute ospfv3 match external
     - network 192.0.2.0/24
     - network 203.0.113.0/24 route-map MAP01
     - neighbor 192.0.2.1 activate
@@ -23,7 +23,7 @@ merged:
     address_family:
       - afi: "ipv4"
         redistribute:
-          - protocol: "ospf3"
+          - protocol: "ospfv3"
             ospf_route: "external"
         network:
           - address: "192.0.2.0/24"
@@ -67,12 +67,12 @@ replaced:
     - router bgp 65536
     - vrf vrft
     - address-family ipv4
-    - redistribute ospf3 match external
+    - redistribute ospfv3 match external
     - exit
     - exit
     - address-family ipv4
     - redistribute isis level-2
-    - no redistribute ospf3 match external
+    - no redistribute ospfv3 match external
     - no network 192.0.2.0/24
     - no network 203.0.113.0/24 route-map MAP01
     - no neighbor peer2 default-originate always
@@ -83,7 +83,7 @@ replaced:
     address_family:
       - afi: "ipv4"
         redistribute:
-          - protocol: "ospf3"
+          - protocol: "ospfv3"
             ospf_route: "external"
         network:
           - address: "192.0.2.0/24"
@@ -120,7 +120,7 @@ replaced:
       - afi: "ipv4"
         vrf: "vrft"
         redistribute:
-          - protocol: "ospf3"
+          - protocol: "ospfv3"
             ospf_route: "external"
         bgp_params:
           additional_paths: "receive"
@@ -130,7 +130,7 @@ overridden:
     - router bgp 65536
     - vrf vrft
     - address-family ipv4
-    - redistribute ospf3 match external
+    - redistribute ospfv3 match external
     - exit
     - exit
     - address-family ipv6
@@ -145,7 +145,7 @@ overridden:
       - afi: "ipv4"
         vrf: "vrft"
         redistribute:
-          - protocol: "ospf3"
+          - protocol: "ospfv3"
             ospf_route: "external"
         bgp_params:
           additional_paths: "receive"
@@ -172,7 +172,7 @@ gathered:
             route_map: "MAP01"
         redistribute:
           - ospf_route: "external"
-            protocol: "ospf3"
+            protocol: "ospfv3"
       - afi: "ipv4"
         bgp_params:
           additional_paths: "receive"

--- a/tests/integration/targets/eos_bgp_global/defaults/main.yaml
+++ b/tests/integration/targets/eos_bgp_global/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: ''
+testcase: '[^_].*'
 test_items: []

--- a/tests/integration/targets/eos_bgp_global/defaults/main.yaml
+++ b/tests/integration/targets/eos_bgp_global/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '[^_].*'
+testcase: ''
 test_items: []

--- a/tests/integration/targets/eos_config/defaults/main.yaml
+++ b/tests/integration/targets/eos_config/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '*'
+testcase: ''
 test_items: []

--- a/tests/integration/targets/eos_interface/defaults/main.yaml
+++ b/tests/integration/targets/eos_interface/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-testcase: '*'
+testcase: ''

--- a/tests/integration/targets/eos_ospfv3/defaults/main.yaml
+++ b/tests/integration/targets/eos_ospfv3/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '[^_].*'
+testcase: ''
 test_items: []

--- a/tests/unit/modules/network/eos/fixtures/eos_bgp_af_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_bgp_af_config.cfg
@@ -12,7 +12,7 @@ router bgp 10
       neighbor peer2 default-originate always
       network 1.1.1.0/24
       network 1.5.1.0/24 route-map MAP01
-      redistribute ospf3 match external
+      redistribute ospfv3 match external
    !
    vrf vrft
       address-family ipv4

--- a/tests/unit/modules/network/eos/test_eos_bgp_address_family.py
+++ b/tests/unit/modules/network/eos/test_eos_bgp_address_family.py
@@ -59,7 +59,7 @@ class TestEosBgpafModule(TestEosModule):
                         dict(
                             afi="ipv4",
                             redistribute=[
-                                dict(protocol="ospf3", ospf_route="external")
+                                dict(protocol="ospfv3", ospf_route="external")
                             ],
                             network=[
                                 dict(address="1.1.1.0/24"),
@@ -101,7 +101,7 @@ class TestEosBgpafModule(TestEosModule):
                         dict(
                             afi="ipv4",
                             redistribute=[
-                                dict(protocol="ospf3", ospf_route="external")
+                                dict(protocol="ospfv3", ospf_route="external")
                             ],
                             neighbor=[
                                 dict(
@@ -144,7 +144,7 @@ class TestEosBgpafModule(TestEosModule):
                         dict(
                             afi="ipv4",
                             redistribute=[
-                                dict(protocol="ospf3", ospf_route="external")
+                                dict(protocol="ospfv3", ospf_route="external")
                             ],
                             neighbor=[
                                 dict(
@@ -193,7 +193,7 @@ class TestEosBgpafModule(TestEosModule):
                         dict(
                             afi="ipv4",
                             redistribute=[
-                                dict(protocol="ospf3", ospf_route="external")
+                                dict(protocol="ospfv3", ospf_route="external")
                             ],
                             network=[
                                 dict(address="1.1.1.0/24"),
@@ -235,7 +235,7 @@ class TestEosBgpafModule(TestEosModule):
                         dict(
                             afi="ipv4",
                             redistribute=[
-                                dict(protocol="ospf3", ospf_route="external")
+                                dict(protocol="ospfv3", ospf_route="external")
                             ],
                             neighbor=[
                                 dict(
@@ -286,7 +286,7 @@ class TestEosBgpafModule(TestEosModule):
                         dict(
                             afi="ipv4",
                             redistribute=[
-                                dict(protocol="ospf3", ospf_route="external")
+                                dict(protocol="ospfv3", ospf_route="external")
                             ],
                             network=[
                                 dict(address="1.1.1.0/24"),
@@ -355,7 +355,7 @@ class TestEosBgpafModule(TestEosModule):
             "!",
             "vrf vrft",
             "address-family ipv4",
-            "redistribute ospf3 match external",
+            "redistribute ospfv3 match external",
             "route-target both 465:11",
             "!",
         ]
@@ -384,7 +384,7 @@ class TestEosBgpafModule(TestEosModule):
                     "afi": "ipv4",
                     "vrf": "vrft",
                     "redistribute": [
-                        {"protocol": "ospf3", "ospf_route": "external`"}
+                        {"protocol": "ospfv3", "ospf_route": "external`"}
                     ],
                     "route_target": {"mode": "both", "target": "465:11"},
                 },
@@ -413,7 +413,7 @@ class TestEosBgpafModule(TestEosModule):
                         {"address": "1.5.1.0/24", "route_map": "MAP01"},
                     ],
                     "redistribute": [
-                        {"ospf_route": "external", "protocol": "ospf3"}
+                        {"ospf_route": "external", "protocol": "ospfv3"}
                     ],
                 },
                 {
@@ -442,7 +442,7 @@ class TestEosBgpafModule(TestEosModule):
                         dict(
                             afi="ipv4",
                             redistribute=[
-                                dict(protocol="ospf3", ospf_route="external")
+                                dict(protocol="ospfv3", ospf_route="external")
                             ],
                             network=[
                                 dict(address="1.1.1.0/24"),
@@ -470,7 +470,7 @@ class TestEosBgpafModule(TestEosModule):
         rendered_cmds = [
             "router bgp 10",
             "address-family ipv4",
-            "redistribute ospf3 match external",
+            "redistribute ospfv3 match external",
             "network 1.1.1.0/24",
             "network 1.5.1.0/24 route-map MAP01",
             "neighbor peer2 default-originate always",


### PR DESCRIPTION
When running the integration tests in this repo against a VM with 4.26.1F, the tests fail because of a typo.

```
TASK [eos_bgp_address_family : Replace given bgp_address_family configuration] ***************************************
fatal: [localvm]: FAILED! => {"changed": false, "msg": "value of protocol must be one of: isis, ospf3, dhcp, got: ospfv3 found in config -> address_family -> redistribute"}
```


```
localhost#show version
 vEOS
Hardware version:
Serial number:
Hardware MAC address: 000c.29a9.1d52
System MAC address: 000c.29a9.1d52

Software image version: 4.26.1F
Architecture: x86_64
Internal build version: 4.26.1F-22602519.4261F
Internal build ID: 1eca5f74-3ced-441a-9137-c966e8f0319d
Image format version: 01.00

Uptime: 0 weeks, 0 days, 1 hours and 8 minutes
Total memory: 4002556 kB
Free memory: 2846912 kB
```

Checking the available commands, it appears that it is supposed to be `ospfv3`, not `ospf3`

```
localhost(config)#router ?
  bfd                  Bidirectional Forwarding Detection
  bgp                  Border Gateway Protocol
  general              Protocol independent routing configuration
  igmp                 IGMP related status and configuration
  isis                 Intermediate System - Intermediate System (IS-IS)
  kernel               Routes installed by kernel
  l2-vpn               l2-vpn configuration
  msdp                 MSDP protocol commands
  multicast            Multicast routing commands
  ospf                 OSPF protocol
  ospfv3               OSPF Version 3
  pim                  Protocol Independent Multicast (PIM)
  rip                  Routing Information Protocol
  traffic-engineering  Traffic-engineering global config
```

This is related to #133 

