### PR TITLE
eos_route_maps:Add support for multiple keys under match.ip/ipv6 in rmtemplate

### DIFF
--- a/changelogs/fragments/support_multiple_key_ip_dict_route_maps.yml
+++ b/changelogs/fragments/support_multiple_key_ip_dict_route_maps.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Added fix to support multiple keys under ip and ipv6 dict in parser template.

--- a/plugins/module_utils/network/eos/config/route_maps/route_maps.py
+++ b/plugins/module_utils/network/eos/config/route_maps/route_maps.py
@@ -250,7 +250,12 @@ class Route_maps(ResourceModule):
                     else:
                         h = {}
                     self.compare(
-                        parsers=["match.ip", "match.ipaddress", "match.ipv6address", "match.ipv6"],
+                        parsers=[
+                            "match.ip",
+                            "match.ipaddress",
+                            "match.ipv6address",
+                            "match.ipv6",
+                        ],
                         want={"entries": {"match": {k: {k_ip: v_ip}}}},
                         have={"entries": {"match": {k: h}}},
                     )
@@ -265,8 +270,14 @@ class Route_maps(ResourceModule):
             if k in ["ip", "ipv6"]:
                 for hk, hv in iteritems(v):
                     self.compare(
-                        parsers=["match.ip", "match.ipaddress", "match.ipv6address", "match.ipv6"],
-                        want={}, have={"entries": {"match": {k: {hk: hv}}}}
+                        parsers=[
+                            "match.ip",
+                            "match.ipaddress",
+                            "match.ipv6address",
+                            "match.ipv6",
+                        ],
+                        want={},
+                        have={"entries": {"match": {k: {hk: hv}}}},
                     )
                 continue
             self.compare(

--- a/plugins/module_utils/network/eos/config/route_maps/route_maps.py
+++ b/plugins/module_utils/network/eos/config/route_maps/route_maps.py
@@ -243,12 +243,32 @@ class Route_maps(ResourceModule):
         w_match = want.pop("match", {})
         h_match = have.pop("match", {})
         for k, v in iteritems(w_match):
+            if k in ["ip", "ipv6"]:
+                for k_ip, v_ip in iteritems(v):
+                    if h_match.get(k):
+                        h = {k_ip: h_match[k].pop(k_ip, {})}
+                    else:
+                        h = {}
+                    self.compare(
+                        parsers=["match.ip", "match.ipaddress", "match.ipv6address", "match.ipv6"],
+                        want={"entries": {"match": {k: {k_ip: v_ip}}}},
+                        have={"entries": {"match": {k: h}}},
+                    )
+                h_match.pop(k, {})
+                continue
             self.compare(
                 parsers=parsers,
                 want={"entries": {"match": {k: v}}},
                 have={"entries": {"match": {k: h_match.pop(k, {})}}},
             )
         for k, v in iteritems(h_match):
+            if k in ["ip", "ipv6"]:
+                for hk, hv in iteritems(v):
+                    self.compare(
+                        parsers=["match.ip", "match.ipaddress", "match.ipv6address", "match.ipv6"],
+                        want={}, have={"entries": {"match": {k: {hk: hv}}}}
+                    )
+                continue
             self.compare(
                 parsers=parsers, want={}, have={"entries": {"match": {k: v}}}
             )

--- a/plugins/module_utils/network/eos/facts/route_maps/route_maps.py
+++ b/plugins/module_utils/network/eos/facts/route_maps/route_maps.py
@@ -96,11 +96,14 @@ class Route_mapsFacts(object):
                                 if entry_k == "match":
                                     if "ip" in entry_v or "ipv6" in entry_v:
                                         for ipk, ipv in iteritems(entry_v):
-                                            if "ip" in entry_v: 
+                                            if "ip" in entry_v:
                                                 match_ip.update(ipv)
-                                            if "ipv6" in entry_v: 
+                                            if "ipv6" in entry_v:
                                                 match_ipv6.update(ipv)
-                                        matchv = {"ip": match_ip , "ipv6": match_ipv6}
+                                        matchv = {
+                                            "ip": match_ip,
+                                            "ipv6": match_ipv6,
+                                        }
                                     else:
                                         matchv = entry_v
                                     match_dict.update(matchv)

--- a/plugins/module_utils/network/eos/facts/route_maps/route_maps.py
+++ b/plugins/module_utils/network/eos/facts/route_maps/route_maps.py
@@ -88,11 +88,22 @@ class Route_mapsFacts(object):
                     if k == "entries":
                         e_list = []
                         match_dict = {}
+                        match_ip = {}
+                        match_ipv6 = {}
                         set_dict = {}
                         for el in v:
                             for entry_k, entry_v in iteritems(el):
                                 if entry_k == "match":
-                                    match_dict.update(entry_v)
+                                    if "ip" in entry_v or "ipv6" in entry_v:
+                                        for ipk, ipv in iteritems(entry_v):
+                                            if "ip" in entry_v: 
+                                                match_ip.update(ipv)
+                                            if "ipv6" in entry_v: 
+                                                match_ipv6.update(ipv)
+                                        matchv = {"ip": match_ip , "ipv6": match_ipv6}
+                                    else:
+                                        matchv = entry_v
+                                    match_dict.update(matchv)
                                 elif entry_k == "set":
                                     set_dict.update(entry_v)
                                 else:

--- a/plugins/module_utils/network/eos/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/eos/rm_templates/route_maps.py
@@ -192,7 +192,8 @@ def _tmplt_route_map_match_ip(config_data):
             command += "next-hop prefix-list " + config_data["next_hop"]
         elif config_data.get("resolved_next_hop"):
             command += (
-                "resolved-next-hop prefix-list " + config_data["resolved_next_hop"]
+                "resolved-next-hop prefix-list "
+                + config_data["resolved_next_hop"]
             )
     return command
 
@@ -206,7 +207,8 @@ def _tmplt_route_map_match_ipv6(config_data):
             command += "next-hop prefix-list " + config_data["next_hop"]
         elif config_data.get("resolved_next_hop"):
             command += (
-                "resolved-next-hop prefix-list " + config_data["resolved_next_hop"]
+                "resolved-next-hop prefix-list "
+                + config_data["resolved_next_hop"]
             )
     return command
 

--- a/tests/unit/modules/network/eos/test_eos_route_maps.py
+++ b/tests/unit/modules/network/eos/test_eos_route_maps.py
@@ -281,7 +281,9 @@ class TestEosRoute_MapsModule(TestEosModule):
                             dict(
                                 action="permit",
                                 match=dict(
-                                    ipv6=dict(resolved_next_hop="listr")
+                                    ipv6=dict(
+                                        address=dict(prefix_list="test_prefix")
+                                    )
                                 ),
                                 set=dict(
                                     metric=dict(igp_param="igp-nexthop-cost")
@@ -291,6 +293,11 @@ class TestEosRoute_MapsModule(TestEosModule):
                             dict(
                                 action="deny",
                                 sequence=90,
+                                match=dict(
+                                    ip=dict(
+                                        address=dict(prefix_list="test_prefix")
+                                    )
+                                ),
                                 set=dict(
                                     extcommunity=dict(
                                         rt=dict(vpn="22:11", delete=True)
@@ -307,12 +314,13 @@ class TestEosRoute_MapsModule(TestEosModule):
             "no route-map mapmerge deny 25",
             "no route-map mapmerge2 deny 45",
             "route-map mapmerge permit 10",
-            "match ipv6 resolved-next-hop prefix-list listr",
+            "match ipv6 address prefix-list test_prefix",
             "set metric igp-nexthop-cost",
             "no match router-id prefix-list 22",
             "no set bgp bestpath as-path weight 20",
             "no description",
             "route-map mapmerge deny 90",
+            "match ip address prefix-list test_prefix",
             "set extcommunity rt 22:11 delete",
             "set ip next-hop unchanged",
         ]


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes: #235 
This PR fixes the typo and other bugs related to the formation of "match ip ....." command in eos route maps.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
