### PR TITLE
Make "action" a required attribute for prefix list entries

### DIFF
--- a/plugins/module_utils/network/eos/argspec/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/eos/argspec/prefix_lists/prefix_lists.py
@@ -55,6 +55,7 @@ class Prefix_listsArgs(object):  # pylint: disable=R0903
                                 "action": {
                                     "type": "str",
                                     "choices": ["deny", "permit"],
+                                    "required": True,
                                 },
                                 "address": {"type": "str"},
                                 "match": {


### PR DESCRIPTION
Without action set, entries will silently fail to be created,
which can cause confusion