### PR TITLE
Disable intergration tests inorder to support eos image upgrade

### DIFF
--- a/changelogs/fragments/disable_integration_tests.yaml
+++ b/changelogs/fragments/disable_integration_tests.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Disable integration tests until cli change fix PRs are merged for eos 4.24

--- a/tests/integration/targets/eos_bgp_address_family/defaults/main.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '[^_].*'
+testcase: ''
 test_items: []

--- a/tests/integration/targets/eos_bgp_global/defaults/main.yaml
+++ b/tests/integration/targets/eos_bgp_global/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '[^_].*'
+testcase: ''
 test_items: []

--- a/tests/integration/targets/eos_lacp_interfaces/defaults/main.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '[^_].*'
+testcase: ''
 test_items: []

--- a/tests/integration/targets/eos_lldp_global/defaults/main.yaml
+++ b/tests/integration/targets/eos_lldp_global/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '[^_].*'
+testcase: ''
 test_items: []

--- a/tests/integration/targets/eos_static_routes/defaults/main.yaml
+++ b/tests/integration/targets/eos_static_routes/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '[^_].*'
+testcase: ''
 test_items: []

--- a/tests/integration/targets/eos_system/defaults/main.yaml
+++ b/tests/integration/targets/eos_system/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '*'
+testcase: ''
 test_items: []

--- a/tests/integration/targets/eos_vrf/defaults/main.yaml
+++ b/tests/integration/targets/eos_vrf/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: '*'
+testcase: ''
 test_items: []


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The tests will be enabled, once failures due to cli changes in the latest sw version of eos, are fixed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
