### PR TITLE
Change 'bgp listen limit' to 'dynamic peer max'

### DIFF
--- a/changelogs/fragments/bgp_listen_limit_cli_change.yml
+++ b/changelogs/fragments/bgp_listen_limit_cli_change.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Change cli 'bgp listen limit' to 'dynamic peer max' ( cli changes in eos 4.23 ).

--- a/plugins/module_utils/network/eos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/eos/rm_templates/bgp_global.py
@@ -126,11 +126,9 @@ def _tmplt_bgp_params(config_data):
         )
     elif config_data["bgp_params"].get("listen"):
         # from eos 4.23 , 'bgp listen limit ' is replaced by 'dynamic peer max'.
-        command = "dynamic peer max " 
+        command = "dynamic peer max "
         if config_data["bgp_params"]["listen"].get("limit"):
-            command += "{limit}".format(
-                **config_data["bgp_params"]["listen"]
-            )
+            command += "{limit}".format(**config_data["bgp_params"]["listen"])
         else:
             command += " range {address} peer group".format(
                 **config_data["bgp_params"]["listen"]["range"]

--- a/plugins/module_utils/network/eos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/eos/rm_templates/bgp_global.py
@@ -125,9 +125,10 @@ def _tmplt_bgp_params(config_data):
             **config_data["bgp_params"]
         )
     elif config_data["bgp_params"].get("listen"):
-        command += " listen"
+        # from eos 4.23 , 'bgp listen limit ' is replaced by 'dynamic peer max'.
+        command = "dynamic peer max " 
         if config_data["bgp_params"]["listen"].get("limit"):
-            command += " limit {limit}".format(
+            command += "{limit}".format(
                 **config_data["bgp_params"]["listen"]
             )
         else:
@@ -1096,9 +1097,7 @@ class Bgp_globalTemplate(NetworkTemplate):
             "name": "bgp_params.listen_limit",
             "getval": re.compile(
                 r"""
-                \s*bgp
-                \s+listen
-                \s+limit
+                \s*dynamic\speer\smax
                 \s+(?P<limit>\d+)
                 *$""",
                 re.VERBOSE,

--- a/tests/integration/targets/eos_bgp_global/tests/common/merged.yaml
+++ b/tests/integration/targets/eos_bgp_global/tests/common/merged.yaml
@@ -19,6 +19,9 @@
               summary_only: true
             - address: "192.0.2.0/24"
               attribute_map: "attrmap"
+          bgp_params:
+            listen:
+              limit: 30
           neighbor:
             - maximum_received_routes:
                 count: 12000
@@ -61,10 +64,10 @@
 
     - assert:
         that:
-          - result.commands|length == 21
+          - result.commands|length == 22
           - result.changed == true
           - result.commands|symmetric_difference(merged.commands) == []
-          - result.after == populate.global
+          - result.after == merged.after
           - result.before == {}
 
     - name: Idempotency check

--- a/tests/integration/targets/eos_bgp_global/tests/common/rendered.yaml
+++ b/tests/integration/targets/eos_bgp_global/tests/common/rendered.yaml
@@ -60,4 +60,4 @@
     - assert:
         that:
           - result.changed == false
-          - result.rendered|symmetric_difference(merged.commands) == []
+          - result.rendered|symmetric_difference(rendered.commands) == []

--- a/tests/integration/targets/eos_bgp_global/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_bgp_global/tests/common/rtt.yaml
@@ -63,7 +63,7 @@
         that:
           - baseconfig.commands|length == 21
           - baseconfig.changed == true
-          - baseconfig.commands|symmetric_difference(merged.commands) == []
+          - baseconfig.commands|symmetric_difference(rendered.commands) == []
           - baseconfig.after == populate.global
 
     - become: true

--- a/tests/integration/targets/eos_bgp_global/vars/main.yaml
+++ b/tests/integration/targets/eos_bgp_global/vars/main.yaml
@@ -19,9 +19,60 @@ merged:
     - redistribute rip route-map MAP01
     - aggregate-address 203.0.113.0/24 as-set summary-only
     - aggregate-address 192.0.2.0/24 attribute-map attrmap
+    - dynamic peer max 30
     - timers bgp 44 100
     - ucmp link-bandwidth recursive
     - vlan-aware-bundle bundle1 bundle3
+  after:
+    as_number: "65536"
+    aggregate_address:
+      - address: "192.0.2.0/24"
+        attribute_map: "attrmap"
+      - address: "203.0.113.0/24"
+        as_set: true
+        summary_only: true
+    bgp_params:
+      listen:
+        limit: 30
+    neighbor:
+      - maximum_received_routes:
+          count: 12000
+        peer: "peer1"
+        peer_group: "peer1"
+        send_community:
+          community_attribute: "link-bandwidth"
+          divide: "ratio"
+          link_bandwidth_attribute: "divide"
+      - maximum_received_routes:
+          count: 12000
+        peer: "peer2"
+        peer_group: "peer2"
+    redistribute:
+      - protocol: "ospf"
+        ospf_route: "nssa_external_2"
+      - protocol: "static"
+      - protocol: "rip"
+        route_map: "MAP01"
+    timers:
+      holdtime: 100
+      keepalive: 44
+    ucmp:
+      link_bandwidth:
+        mode: "recursive"
+    vlan_aware_bundle: "bundle1 bundle3"
+    vrfs:
+      - vrf: "vrf01"
+        default_metric: 433
+        network:
+          - address: "10.1.0.0/16"
+          - address: "6.6.6.0/24"
+            route_map: "netmap1"
+        redistribute:
+          - protocol: "isis"
+            isis_level: "level-2"
+        route_target:
+          action: "export"
+          target: "44:22"
 
 deleted:
   after:

--- a/tests/integration/targets/eos_bgp_global/vars/main.yaml
+++ b/tests/integration/targets/eos_bgp_global/vars/main.yaml
@@ -167,3 +167,27 @@ populate:
         route_target:
           action: "export"
           target: "44:22"
+
+rendered:
+  commands:
+    - router bgp 65536
+    - vrf vrf01
+    - redistribute isis level-2
+    - network 6.6.6.0/24 route-map netmap1
+    - network 10.1.0.0/16
+    - default-metric 433
+    - route-target export 44:22
+    - exit
+    - neighbor peer1 maximum-routes 12000
+    - neighbor peer1 peer group
+    - neighbor peer1 send-community link-bandwidth divide ratio
+    - neighbor peer2 maximum-routes 12000
+    - neighbor peer2 peer group
+    - redistribute ospf match nssa-external 2
+    - redistribute static
+    - redistribute rip route-map MAP01
+    - aggregate-address 203.0.113.0/24 as-set summary-only
+    - aggregate-address 192.0.2.0/24 attribute-map attrmap
+    - timers bgp 44 100
+    - ucmp link-bandwidth recursive
+    - vlan-aware-bundle bundle1 bundle3

--- a/tests/unit/modules/network/eos/test_eos_bgp_global.py
+++ b/tests/unit/modules/network/eos/test_eos_bgp_global.py
@@ -199,7 +199,7 @@ class TestEosBgpglobalModule(TestEosModule):
             "neighbor peer2 maximum-routes 12000",
             "neighbor peer2 shutdown",
             "bgp route-reflector preserve-attributes always",
-            "bgp listen limit 20",
+            "dynamic peer max 20",
             "bgp log-neighbor-changes",
             "bgp missing-policy direction in action deny",
             "bgp monitoring",


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Related  #https://github.com/ansible-collections/arista.eos/issues/133

This PR takes care of changing the 'bgp listen limit' cli which is no more supported in eos sw versions >= 4.23.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
