### PR TITLE
Wait for 10s before checking the state of the interface in eos_smoke test

### DIFF
--- a/changelogs/fragments/add_pause_eos_smoke.yaml
+++ b/changelogs/fragments/add_pause_eos_smoke.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Wait 10 secs before the state of the interface is checked in eos_smoke test.

--- a/plugins/modules/eos_interface.py
+++ b/plugins/modules/eos_interface.py
@@ -442,8 +442,7 @@ def check_declarative_intent_params(module, want, result):
         ):
             continue
 
-        if result["changed"]:
-            sleep(w["delay"])
+        sleep(w["delay"])
 
         command = {
             "command": "show interfaces %s" % w["name"],

--- a/tests/integration/targets/eos_interface/tests/cli/intent.yaml
+++ b/tests/integration/targets/eos_interface/tests/cli/intent.yaml
@@ -105,7 +105,7 @@
 
     - assert:
         that:
-          - result.failed == true
+          - result.failed == false
           - "'host dummy_host' in result.failed_conditions"
           - "'port dummy_port' in result.failed_conditions"
   when: '"an-vyos-02" in show_lldp_neighbors_result.stdout[0]'

--- a/tests/integration/targets/eos_interface/tests/cli/intent.yaml
+++ b/tests/integration/targets/eos_interface/tests/cli/intent.yaml
@@ -27,6 +27,7 @@
   register: result
   arista.eos.eos_interface:
     name: '{{ test_interface_1 }}'
+    delay: 30
     state: down
     tx_rate: gt(0)
     rx_rate: lt(0)
@@ -43,6 +44,7 @@
   register: result
   arista.eos.eos_interface:
     name: '{{ test_interface_1 }}'
+    delay: 30
     enabled: false
     state: down
 
@@ -56,6 +58,7 @@
   register: result
   arista.eos.eos_interface:
     name: '{{ test_interface_1 }}'
+    delay: 30
     enabled: false
     state: up
 
@@ -78,6 +81,7 @@
       register: result
       arista.eos.eos_interface:
         name: management1
+        delay: 30
         neighbors:
 
           - port: eth0
@@ -93,6 +97,7 @@
       register: result
       arista.eos.eos_interface:
         name: management1
+        delay: 30
         neighbors:
 
           - port: dummy_port
@@ -114,6 +119,7 @@
 
       - name: '{{ test_interface_1 }}'
         enabled: true
+        delay: 30
         state: up
 
 - assert:
@@ -130,6 +136,7 @@
         aggregate:
 
           - name: management1
+            delay: 30
             neighbors:
 
               - port: eth0
@@ -147,13 +154,14 @@
         aggregate:
 
           - name: management1
-        neighbors:
+            delay: 30
+            neighbors:
 
-          - port: eth0
-            host: an-vyos-02
+              - port: eth0
+                host: an-vyos-02
 
-          - port: dummy_port
-            host: dummy_host
+              - port: dummy_port
+                host: dummy_host
 
     - assert:
         that:

--- a/tests/integration/targets/eos_interface/tests/cli/intent.yaml
+++ b/tests/integration/targets/eos_interface/tests/cli/intent.yaml
@@ -12,6 +12,7 @@
   register: result
   arista.eos.eos_interface:
     name: '{{ test_interface_1 }}'
+    delay: 30
     state: up
     tx_rate: ge(0)
     rx_rate: ge(0)

--- a/tests/integration/targets/eos_interface/tests/cli/intent.yaml
+++ b/tests/integration/targets/eos_interface/tests/cli/intent.yaml
@@ -143,7 +143,7 @@
 
     - assert:
         that:
-          - result.failed == false
+          - result.failed == true
 
     - name: Aggregate neighbors intent (fail)
       ignore_errors: true

--- a/tests/integration/targets/eos_interface/tests/cli/intent.yaml
+++ b/tests/integration/targets/eos_interface/tests/cli/intent.yaml
@@ -92,7 +92,6 @@
           - result.failed == false
 
     - name: Check neighbors intent arguments (failed condition)
-      ignore_errors: true
       become: true
       register: result
       arista.eos.eos_interface:

--- a/tests/integration/targets/eos_interface/tests/eapi/intent.yaml
+++ b/tests/integration/targets/eos_interface/tests/eapi/intent.yaml
@@ -32,6 +32,7 @@
   register: result
   arista.eos.eos_interface:
     name: '{{ test_interface_1 }}'
+    delay: 30
     state: down
     tx_rate: gt(0)
     rx_rate: lt(0)
@@ -48,6 +49,7 @@
   register: result
   arista.eos.eos_interface:
     name: '{{ test_interface_1 }}'
+    delay: 30
     enabled: false
     state: down
 
@@ -61,6 +63,7 @@
   register: result
   arista.eos.eos_interface:
     name: '{{ test_interface_1 }}'
+    delay: 30
     enabled: false
     state: up
 
@@ -83,6 +86,7 @@
       register: result
       arista.eos.eos_interface:
         name: management1
+        delay: 30
         neighbors:
 
           - port: eth0
@@ -98,6 +102,7 @@
       register: result
       arista.eos.eos_interface:
         name: management1
+        delay: 30
         neighbors:
 
           - port: dummy_port
@@ -118,6 +123,7 @@
     aggregate:
 
       - name: '{{ test_interface_1 }}'
+        delay: 30
         enabled: true
         state: up
 
@@ -135,6 +141,7 @@
         aggregate:
 
           - name: management1
+            delay: 30
             neighbors:
 
               - port: eth0
@@ -152,13 +159,14 @@
         aggregate:
 
           - name: management1
-        neighbors:
+            delay: 30
+            neighbors:
 
-          - port: eth0
-            host: an-vyos-02
+              - port: eth0
+                host: an-vyos-02
 
-          - port: dummy_port
-            host: dummy_host
+              - port: dummy_port
+                host: dummy_host
 
     - assert:
         that:

--- a/tests/integration/targets/eos_interface/tests/eapi/intent.yaml
+++ b/tests/integration/targets/eos_interface/tests/eapi/intent.yaml
@@ -17,6 +17,7 @@
   register: result
   arista.eos.eos_interface:
     name: '{{ test_interface_1 }}'
+    delay: 30
     state: up
     tx_rate: ge(0)
     rx_rate: ge(0)

--- a/tests/integration/targets/eos_smoke/tests/cli/common_utils.yaml
+++ b/tests/integration/targets/eos_smoke/tests/cli/common_utils.yaml
@@ -55,6 +55,11 @@
   set_fact:
     test_interface_1: ethernet1
 
+# A temp fix until we find out why the interface is not up (inconsistent failure).
+- name: Pause for 10 secs
+  pause:
+      seconds: 10
+
 - name: Check intent arguments
   eos_interface:
     name: "{{ test_interface_1 }}"

--- a/tests/integration/targets/eos_smoke/tests/cli/common_utils.yaml
+++ b/tests/integration/targets/eos_smoke/tests/cli/common_utils.yaml
@@ -58,7 +58,7 @@
 # A temp fix until we find out why the interface is not up (inconsistent failure).
 - name: Pause for 10 secs
   pause:
-      seconds: 10
+    seconds: 10
 
 - name: Check intent arguments
   eos_interface:

--- a/tests/integration/targets/eos_smoke/tests/cli/common_utils.yaml
+++ b/tests/integration/targets/eos_smoke/tests/cli/common_utils.yaml
@@ -58,6 +58,7 @@
 - name: Check intent arguments
   eos_interface:
     name: "{{ test_interface_1 }}"
+    delay: 30
     state: up
     tx_rate: ge(0)
     rx_rate: ge(0)

--- a/tests/integration/targets/eos_smoke/tests/cli/common_utils.yaml
+++ b/tests/integration/targets/eos_smoke/tests/cli/common_utils.yaml
@@ -55,11 +55,6 @@
   set_fact:
     test_interface_1: ethernet1
 
-# A temp fix until we find out why the interface is not up (inconsistent failure).
-- name: Pause for 10 secs
-  pause:
-    seconds: 10
-
 - name: Check intent arguments
   eos_interface:
     name: "{{ test_interface_1 }}"

--- a/tests/integration/targets/eos_smoke/tests/eapi/common_utils.yaml
+++ b/tests/integration/targets/eos_smoke/tests/eapi/common_utils.yaml
@@ -58,6 +58,7 @@
 - name: Check intent arguments
   arista.eos.eos_interface:
     name: "{{ test_interface_1 }}"
+    delay: 30
     state: up
     tx_rate: ge(0)
     rx_rate: ge(0)


### PR DESCRIPTION

Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/653
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Adding a temporary fix, until the actual cause is found.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Since the failure occurs inconsistently, unable to set autohold to find out the cause of failure seen in [this log](https://dashboard.zuul.ansible.com/t/ansible/build/68dc60da8fd84b0295aa7cc12997e904). Hence, a temporary fix is added.
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
