### PR TITLE
Version parameter support for httpapi and cliconf connections

### DIFF
--- a/changelogs/fragments/support_version_parameter.yaml
+++ b/changelogs/fragments/support_version_parameter.yaml
@@ -1,0 +1,7 @@
+---
+breaking_changes:
+  - eos_command - new suboption ``version`` of parameter ``command``, which controls the JSON response version.
+    Previously the value was assumed to be "latest" for network_cli and "1" for httpapi, but the default will now be "latest" for both connections.
+    This option is also available for use in modules making their own device requests with
+    ``plugins.module_utils.network.eos.eos.run_commands()`` with the same new default behavior.
+    (https://github.com/ansible-collections/arista.eos/pull/258).

--- a/docs/arista.eos.eos_command_module.rst
+++ b/docs/arista.eos.eos_command_module.rst
@@ -149,6 +149,26 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>version</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>1</li>
+                                    <li><div style="color: blue"><b>latest</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Specifies the version of the JSON response returned when I(output=json).</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>prompt</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -566,6 +586,13 @@ Examples
           prompt: \[confirm\]
           answer: y
           newline: false
+
+    - name: Support for 'version' parameter for httpapi and network_cli connections
+      arista.eos.eos_command:
+        commands:
+          - command: "show ip route summary"
+            output: json
+            version: 1
 
 
 

--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -182,9 +182,10 @@ class Cliconf(CliconfBase):
         newline=True,
         output=None,
         check_all=False,
+        version=None,
     ):
         if output:
-            command = self._get_command_with_output(command, output)
+            command = self._get_command_with_output(command, output, version)
         return self.send_command(
             command=command,
             prompt=prompt,
@@ -215,9 +216,10 @@ class Cliconf(CliconfBase):
                 cmd = {"command": cmd}
 
             output = cmd.pop("output", None)
+            version = cmd.pop("version", None)
             if output:
                 cmd["command"] = self._get_command_with_output(
-                    cmd["command"], output
+                    cmd["command"], output, version
                 )
 
             try:
@@ -376,7 +378,7 @@ class Cliconf(CliconfBase):
                 config_context="(config", exit_command="abort"
             )
 
-    def _get_command_with_output(self, command, output):
+    def _get_command_with_output(self, command, output, version):
         options_values = self.get_option_values()
         if output not in options_values["output"]:
             raise ValueError(
@@ -388,4 +390,6 @@ class Cliconf(CliconfBase):
             cmd = "%s | json" % command
         else:
             cmd = command
+        if version != "latest" and "| json" in cmd:
+            cmd = "%s version %s" % (cmd, version)
         return cmd

--- a/plugins/httpapi/eos.py
+++ b/plugins/httpapi/eos.py
@@ -76,7 +76,8 @@ class HttpApi(HttpApiBase):
             data.insert(0, {"cmd": "enable", "input": self._become_pass})
 
         output = message_kwargs.get("output") or "text"
-        request = request_builder(data, output)
+        version = message_kwargs.get("version") or "latest"
+        request = request_builder(data, output, version)
         headers = {"Content-Type": "application/json-rpc"}
 
         _response, response_data = self.connection.send(
@@ -200,8 +201,10 @@ def handle_response(response):
     return results
 
 
-def request_builder(commands, output, reqid=None):
-    params = dict(version=1, cmds=commands, format=output)
+def request_builder(commands, output, version, reqid=None):
+    if version != "latest":
+        version = int(version)
+    params = dict(version=version, cmds=commands, format=output)
     return json.dumps(
         dict(jsonrpc="2.0", id=reqid, method="runCmds", params=params)
     )

--- a/plugins/modules/eos_command.py
+++ b/plugins/modules/eos_command.py
@@ -58,6 +58,12 @@ options:
         - How the remote device should format the command response data.
         type: str
         choices: ["text", "json"]
+      version:
+        description:
+        - Specifies the version of the JSON response returned when I(output=json).
+        type: str
+        choices: ["1", "latest"]
+        default: "latest"
       prompt:
         description:
         - A single regex pattern or a sequence of patterns to evaluate the expected prompt
@@ -223,11 +229,11 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.p
     Conditional,
 )
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    transform_commands,
     to_lines,
 )
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
     run_commands,
+    transform_commands,
 )
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
     eos_argument_spec,

--- a/tests/integration/targets/eos_command/tests/cli/version.yaml
+++ b/tests/integration/targets/eos_command/tests/cli/version.yaml
@@ -1,0 +1,31 @@
+---
+- debug: msg="START cli/version.yaml on connection={{ ansible_connection }}"
+
+- name: Check support for "latest" version parameter value.
+  register: result
+  arista.eos.eos_command:
+    commands:
+      - command: "show ip route summary"
+        output: json
+        version: "latest"
+
+- assert:
+    that:
+      - result.changed == false
+      - result.stdout is defined
+      - result.stdout_lines[0].protoModelStatus is defined
+
+- name: Check support for "1" version parameter value.
+  register: result
+  arista.eos.eos_command:
+    commands:
+      - command: "show ip route summary"
+        output: json
+        version: "1"
+
+- assert:
+    that:
+      - result.changed == false
+      - result.stdout is defined
+
+- debug: msg="END cli/version.yaml"

--- a/tests/integration/targets/eos_command/tests/eapi/version.yaml
+++ b/tests/integration/targets/eos_command/tests/eapi/version.yaml
@@ -1,0 +1,31 @@
+---
+- debug: msg="START eapi/version.yaml on connection={{ ansible_connection }}"
+
+- name: Check support for "latest" version parameter value.
+  register: result
+  arista.eos.eos_command:
+    commands:
+      - command: "show ip route summary"
+        output: json
+        version: "latest"
+
+- assert:
+    that:
+      - result.changed == false
+      - result.stdout is defined
+      - result.stdout_lines[0].protoModelStatus is defined
+
+- name: Check support for "1" version parameter value
+  register: result
+  arista.eos.eos_command:
+    commands:
+      - command: "show ip route summary"
+        output: json
+        version: "1"
+
+- assert:
+    that:
+      - result.changed == false
+      - result.stdout is defined
+
+- debug: msg="END eapi/version.yaml"

--- a/tests/unit/modules/network/eos/test_eos_command.py
+++ b/tests/unit/modules/network/eos/test_eos_command.py
@@ -124,3 +124,19 @@ class TestEosCommandModule(TestEosModule):
             dict(commands=commands, wait_for=wait_for, match="all")
         )
         self.execute_module(failed=True)
+
+    def test_eos_command_check_version_support(self):
+        wait_for = ['result[0] contains "version"']
+        commands = [{"command": "show version", "version": "1"}]
+        set_module_args(
+            dict(commands=commands, wait_for=wait_for, match="all")
+        )
+        self.execute_module()
+
+    def test_eos_command_check_version_support_failure(self):
+        wait_for = ['result[0] contains "version"']
+        commands = [{"command": "show version", "version": "-1"}]
+        set_module_args(
+            dict(commands=commands, wait_for=wait_for, match="all")
+        )
+        self.execute_module(failed=True)


### PR DESCRIPTION
SUMMARY
Add the capability to specify the data model version with eos_command when using httpapi  and network_cli connectivity method.

ISSUE TYPE

- Feature Idea

COMPONENT NAME

- httpapi/eos.py -> https://github.com/ansible-collections/arista.eos/blob/main/plugins/httpapi/eos.py
- httpapi/eos.py -> https://github.com/ansible-collections/arista.eos/blob/main/plugins/cliconf/eos.py
- modules/eos_command.py -> https://github.com/ansible-collections/arista.eos/blob/main/plugins/modules/eos_command.py

ADDITIONAL INFORMATION

For example, a new data models are developed, or to pin to a specific version of the data model it might be desirable to provide eAPI with the desired version.