### PR TITLE
Remove unused debug statements

### DIFF
--- a/changelogs/fragments/remove_debug_from_tests.yaml
+++ b/changelogs/fragments/remove_debug_from_tests.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Remove unused debug statements

--- a/tests/integration/targets/eos_eapi/tests/cli/off.yaml
+++ b/tests/integration/targets/eos_eapi/tests/cli/off.yaml
@@ -36,9 +36,6 @@
     enable_local_http: false
     enable_socket: false
 
-- debug: var=eos_eapi_output
-  when: debug
-
 - name: Expect action to be idempotent
   assert:
     that:

--- a/tests/integration/targets/eos_eapi/tests/cli/on.yaml
+++ b/tests/integration/targets/eos_eapi/tests/cli/on.yaml
@@ -15,9 +15,6 @@
     commands:
       - show management api http-commands | json
 
-- debug: var=http_config
-  when: debug
-
 - name: Expect all EAPI endpoints to be in on state
   assert:
     that:

--- a/tests/integration/targets/eos_eapi/tests/cli/start.yaml
+++ b/tests/integration/targets/eos_eapi/tests/cli/start.yaml
@@ -12,9 +12,6 @@
     commands:
       - show management api http-commands | json
 
-- debug: var=http_config
-  when: debug
-
 - name: Expect EAPI state is on
   assert:
     that: http_config.stdout[0].enabled == true
@@ -24,9 +21,6 @@
   register: eos_eapi_output
   arista.eos.eos_eapi:
     state: started
-
-- debug: var=eos_eapi_output
-  when: debug
 
 - name: Expect action to be idempotent
   assert:

--- a/tests/integration/targets/eos_eapi/tests/cli/stop.yaml
+++ b/tests/integration/targets/eos_eapi/tests/cli/stop.yaml
@@ -12,9 +12,6 @@
     commands:
       - show management api http-commands | json
 
-- debug: var=http_config
-  when: debug
-
 - name: Expect EAPI state is off
   assert:
     that: http_config.stdout[0].enabled == false
@@ -24,9 +21,6 @@
   register: eos_eapi_output
   arista.eos.eos_eapi:
     state: stopped
-
-- debug: var=eos_eapi_output
-  when: debug
 
 - name: Expect action to be idempotent
   assert:


### PR DESCRIPTION
This avoids the need to setup inventory variables.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>