### PR TITLE
Move prepare_eos_tests role to tasks/main.yaml

### DIFF
--- a/changelogs/fragments/move_prepare_eos_tests_role.yaml
+++ b/changelogs/fragments/move_prepare_eos_tests_role.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Move prepare_eos_tests role to tasks/main.yaml from meta/main.yaml.

--- a/tests/integration/targets/eos_acl_interfaces/meta/main.yaml
+++ b/tests/integration/targets/eos_acl_interfaces/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_acl_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/eos_acl_interfaces/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_acls/meta/main.yaml
+++ b/tests/integration/targets/eos_acls/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_acls/tasks/main.yaml
+++ b/tests/integration/targets/eos_acls/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_banner/meta/main.yml
+++ b/tests/integration/targets/eos_banner/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_banner/tasks/main.yaml
+++ b/tests/integration/targets/eos_banner/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_bgp/meta/main.yaml
+++ b/tests/integration/targets/eos_bgp/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_bgp/tasks/main.yaml
+++ b/tests/integration/targets/eos_bgp/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_bgp_address_family/meta/main.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_bgp_address_family/tasks/main.yaml
+++ b/tests/integration/targets/eos_bgp_address_family/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_bgp_global/meta/main.yaml
+++ b/tests/integration/targets/eos_bgp_global/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_bgp_global/tasks/main.yaml
+++ b/tests/integration/targets/eos_bgp_global/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_command/meta/main.yml
+++ b/tests/integration/targets/eos_command/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_command/tasks/main.yaml
+++ b/tests/integration/targets/eos_command/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_config/meta/main.yml
+++ b/tests/integration/targets/eos_config/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_config/tasks/main.yaml
+++ b/tests/integration/targets/eos_config/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_eapi/meta/main.yml
+++ b/tests/integration/targets/eos_eapi/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_eapi/tasks/main.yaml
+++ b/tests/integration/targets/eos_eapi/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_facts/meta/main.yml
+++ b/tests/integration/targets/eos_facts/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_facts/tasks/main.yaml
+++ b/tests/integration/targets/eos_facts/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
 
 - include: eapi.yaml

--- a/tests/integration/targets/eos_interface/meta/main.yml
+++ b/tests/integration/targets/eos_interface/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_interface/tasks/main.yaml
+++ b/tests/integration/targets/eos_interface/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_interfaces/meta/main.yml
+++ b/tests/integration/targets/eos_interfaces/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/eos_interfaces/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_l2_interface/meta/main.yaml
+++ b/tests/integration/targets/eos_l2_interface/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_l2_interface/tasks/main.yaml
+++ b/tests/integration/targets/eos_l2_interface/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_l2_interfaces/meta/main.yml
+++ b/tests/integration/targets/eos_l2_interfaces/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_l2_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/eos_l2_interfaces/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_l3_interface/meta/main.yaml
+++ b/tests/integration/targets/eos_l3_interface/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_l3_interface/tasks/main.yaml
+++ b/tests/integration/targets/eos_l3_interface/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_l3_interfaces/meta/main.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_l3_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/eos_l3_interfaces/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_lacp/meta/main.yml
+++ b/tests/integration/targets/eos_lacp/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_lacp/tasks/main.yaml
+++ b/tests/integration/targets/eos_lacp/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_lacp_interfaces/meta/main.yml
+++ b/tests/integration/targets/eos_lacp_interfaces/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_lacp_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_lag_interfaces/meta/main.yaml
+++ b/tests/integration/targets/eos_lag_interfaces/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_lag_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/eos_lag_interfaces/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_linkagg/meta/main.yaml
+++ b/tests/integration/targets/eos_linkagg/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_linkagg/tasks/main.yaml
+++ b/tests/integration/targets/eos_linkagg/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_lldp/meta/main.yaml
+++ b/tests/integration/targets/eos_lldp/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_lldp/tasks/main.yaml
+++ b/tests/integration/targets/eos_lldp/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_lldp_global/meta/main.yml
+++ b/tests/integration/targets/eos_lldp_global/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_lldp_global/tasks/main.yaml
+++ b/tests/integration/targets/eos_lldp_global/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_lldp_interfaces/meta/main.yml
+++ b/tests/integration/targets/eos_lldp_interfaces/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_lldp_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/eos_lldp_interfaces/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_logging/meta/main.yaml
+++ b/tests/integration/targets/eos_logging/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_logging/tasks/main.yaml
+++ b/tests/integration/targets/eos_logging/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_logging_global/meta/main.yaml
+++ b/tests/integration/targets/eos_logging_global/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_logging_global/tasks/main.yaml
+++ b/tests/integration/targets/eos_logging_global/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_ospf_interfaces/meta/main.yaml
+++ b/tests/integration/targets/eos_ospf_interfaces/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_ospf_interfaces/tasks/main.yaml
+++ b/tests/integration/targets/eos_ospf_interfaces/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_ospfv2/meta/main.yaml
+++ b/tests/integration/targets/eos_ospfv2/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_ospfv2/tasks/main.yaml
+++ b/tests/integration/targets/eos_ospfv2/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_ospfv3/meta/main.yaml
+++ b/tests/integration/targets/eos_ospfv3/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_ospfv3/tasks/main.yaml
+++ b/tests/integration/targets/eos_ospfv3/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_prefix_lists/meta/main.yaml
+++ b/tests/integration/targets/eos_prefix_lists/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_prefix_lists/tasks/main.yaml
+++ b/tests/integration/targets/eos_prefix_lists/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_route_maps/meta/main.yaml
+++ b/tests/integration/targets/eos_route_maps/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_route_maps/tasks/main.yaml
+++ b/tests/integration/targets/eos_route_maps/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_smoke/meta/main.yml
+++ b/tests/integration/targets/eos_smoke/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_smoke/tasks/main.yaml
+++ b/tests/integration/targets/eos_smoke/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
 
 - include: eapi.yaml

--- a/tests/integration/targets/eos_static_route/meta/main.yaml
+++ b/tests/integration/targets/eos_static_route/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_static_route/tasks/main.yaml
+++ b/tests/integration/targets/eos_static_route/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_static_routes/meta/main.yaml
+++ b/tests/integration/targets/eos_static_routes/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_static_routes/tasks/main.yaml
+++ b/tests/integration/targets/eos_static_routes/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_system/meta/main.yml
+++ b/tests/integration/targets/eos_system/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_system/tasks/main.yaml
+++ b/tests/integration/targets/eos_system/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_user/meta/main.yaml
+++ b/tests/integration/targets/eos_user/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_user/tasks/main.yaml
+++ b/tests/integration/targets/eos_user/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_vlan/meta/main.yml
+++ b/tests/integration/targets/eos_vlan/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_vlan/tasks/main.yaml
+++ b/tests/integration/targets/eos_vlan/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_vlans/meta/main.yml
+++ b/tests/integration/targets/eos_vlans/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_vlans/tasks/main.yaml
+++ b/tests/integration/targets/eos_vlans/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli

--- a/tests/integration/targets/eos_vrf/meta/main.yml
+++ b/tests/integration/targets/eos_vrf/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - prepare_eos_tests

--- a/tests/integration/targets/eos_vrf/tasks/main.yaml
+++ b/tests/integration/targets/eos_vrf/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: prepare_eos_tests
+
 - include: cli.yaml
   tags:
     - network_cli


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

prepare_eos_tests role is moved to tasks/main.yaml in order to support the tests run in network-ee.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
