### PR TITLE
Document expected suboptions to eos_command's commands argument

### DIFF
--- a/changelogs/fragments/280-command-spec.yaml
+++ b/changelogs/fragments/280-command-spec.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - eos_command - document valid suboptions for `commands` argument.

--- a/docs/arista.eos.eos_command_module.rst
+++ b/docs/arista.eos.eos_command_module.rst
@@ -563,7 +563,7 @@ Examples
       arista.eos.eos_command:
         commands:
         - command: reload power
-          prompt: "\[confirm\]"
+          prompt: \[confirm\]
           answer: y
           newline: false
 

--- a/docs/arista.eos.eos_command_module.rst
+++ b/docs/arista.eos.eos_command_module.rst
@@ -48,7 +48,7 @@ Parameters
                 </td>
                 <td>
                         <div>The commands to send to the remote EOS device over the configured provider.  The resulting output from the command is returned.  If the <em>wait_for</em> argument is provided, the module is not returned until the condition is satisfied or the number of <em>retries</em> has been exceeded.</div>
-                        <div>If a command sent to the device requires answering a prompt, it is possible to pass a dict containing command, answer and prompt. Common answers are &#x27;y&#x27; or &quot;\r&quot; (carriage return, must be double quotes). Refer below examples.</div>
+                        <div>Commands may be represented either as simple strings or as dictionaries as described below. Refer to the Examples setion for some common uses.</div>
                 </td>
             </tr>
                                 <tr>
@@ -537,26 +537,35 @@ Examples
         - command: show version
           output: json
 
-    - name: using cli transport, check whether the switch is in maintenance mode
+    - name: check whether the switch is in maintenance mode
       arista.eos.eos_command:
         commands: show maintenance
         wait_for: result[0] contains 'Under Maintenance'
 
-    - name: using cli transport, check whether the switch is in maintenance mode using
-        json output
+    - name: check whether the switch is in maintenance mode using json output
       arista.eos.eos_command:
-        commands: show maintenance | json
+        commands:
+        - command: show maintenance
+          output: json
         wait_for: result[0].units.System.state eq 'underMaintenance'
 
-    - name: using eapi transport check whether the switch is in maintenance, with 8 retries
+    - name: check whether the switch is in maintenance, with 8 retries
         and 2 second interval between retries
       arista.eos.eos_command:
         commands: show maintenance
         wait_for: result[0]['units']['System']['state'] eq 'underMaintenance'
         interval: 2
         retries: 8
-        provider:
-          transport: eapi
+
+    - name: run a command that requires a confirmation. Note that prompt
+        takes regexes, and so strings containing characters like brackets
+        need to be escaped.
+      arista.eos.eos_command:
+        commands:
+        - command: reload power
+          prompt: "\[confirm\]"
+          answer: y
+          newline: false
 
 
 

--- a/docs/arista.eos.eos_command_module.rst
+++ b/docs/arista.eos.eos_command_module.rst
@@ -51,6 +51,138 @@ Parameters
                         <div>If a command sent to the device requires answering a prompt, it is possible to pass a dict containing command, answer and prompt. Common answers are &#x27;y&#x27; or &quot;\r&quot; (carriage return, must be double quotes). Refer below examples.</div>
                 </td>
             </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>answer</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The answer to reply with if <em>prompt</em> is matched. The value can be a single answer or a list of answer for multiple prompts. In case the command execution results in multiple prompts the sequence of the prompt and excepted answer should be in same order.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>check_all</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>By default if any one of the prompts mentioned in <code>prompt</code> option is matched it won&#x27;t check for other prompts. This boolean flag, that when set to <em>True</em> will check for all the prompts mentioned in <code>prompt</code> option in the given order. If the option is set to <em>True</em> all the prompts should be received from remote host if not it will result in timeout.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>command</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The command to send to the remote network device.  The resulting output from the command is returned, unless <em>sendonly</em> is set.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>newline</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The boolean value, that when set to false will send <em>answer</em> to the device without a trailing newline.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>output</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>text</li>
+                                    <li>json</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>How the remote device should format the command response data.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>prompt</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>A single regex pattern or a sequence of patterns to evaluate the expected prompt from <em>command</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sendonly</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The boolean value, that when set to true will send <em>command</em> to the device but not wait for a result.</div>
+                </td>
+            </tr>
+
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>

--- a/docs/arista.eos.eos_eapi_module.rst
+++ b/docs/arista.eos.eos_eapi_module.rst
@@ -568,7 +568,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>Hash of URL endpoints eAPI is listening on per interface</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AnsibleMapping([(&#x27;Management1&#x27;, [&#x27;http://172.26.10.1:80&#x27;])])</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;Management1&#x27;: [&#x27;http://172.26.10.1:80&#x27;]}</div>
                 </td>
             </tr>
     </table>

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -235,11 +235,11 @@ plugin_routing:
     logging:
       redirect: arista.eos.eos_logging
       deprecation:
-        removal_date: '2023-09-01'
+        removal_date: '2024-01-01'
         warning_text: See the plugin documentation for more details
     eos_logging:
       deprecation:
-        removal_date: '2023-09-01'
+        removal_date: '2024-01-01'
         warning_text: See the plugin documentation for more details
     logging_global:
       redirect: arista.eos.eos_logging_global

--- a/plugins/modules/eos_command.py
+++ b/plugins/modules/eos_command.py
@@ -136,7 +136,7 @@ options:
     type: int
 """
 
-EXAMPLES = """
+EXAMPLES = r"""
 - name: run show version on remote devices
   arista.eos.eos_command:
     commands: show version
@@ -193,7 +193,7 @@ EXAMPLES = """
   arista.eos.eos_command:
     commands:
     - command: reload power
-      prompt: "\[confirm\]"
+      prompt: \[confirm\]
       answer: y
       newline: false
 """

--- a/plugins/modules/eos_command.py
+++ b/plugins/modules/eos_command.py
@@ -47,6 +47,57 @@ options:
     required: true
     type: list
     elements: raw
+    suboptions:
+      command:
+        description:
+        - The command to send to the remote network device.  The resulting output from
+          the command is returned, unless I(sendonly) is set.
+        required: true
+        type: str
+      output:
+        description:
+        - How the remote device should format the command response data.
+        type: str
+        choices: ["text", "json"]
+      prompt:
+        description:
+        - A single regex pattern or a sequence of patterns to evaluate the expected prompt
+          from I(command).
+        required: false
+        type: list
+        elements: str
+      answer:
+        description:
+        - The answer to reply with if I(prompt) is matched. The value can be a single
+          answer or a list of answer for multiple prompts. In case the command execution
+          results in multiple prompts the sequence of the prompt and excepted answer should
+          be in same order.
+        required: false
+        type: list
+        elements: str
+      sendonly:
+        description:
+        - The boolean value, that when set to true will send I(command) to the device
+          but not wait for a result.
+        type: bool
+        default: false
+        required: false
+      newline:
+        description:
+        - The boolean value, that when set to false will send I(answer) to the device
+          without a trailing newline.
+        type: bool
+        default: true
+        required: false
+      check_all:
+        description:
+        - By default if any one of the prompts mentioned in C(prompt) option is matched
+          it won't check for other prompts. This boolean flag, that when set to I(True)
+          will check for all the prompts mentioned in C(prompt) option in the given order.
+          If the option is set to I(True) all the prompts should be received from remote
+          host if not it will result in timeout.
+        type: bool
+        default: false
   wait_for:
     description:
     - Specifies what to evaluate from the output of the command and what conditionals

--- a/plugins/modules/eos_command.py
+++ b/plugins/modules/eos_command.py
@@ -41,9 +41,8 @@ options:
       resulting output from the command is returned.  If the I(wait_for) argument
       is provided, the module is not returned until the condition is satisfied or
       the number of I(retries) has been exceeded.
-    - If a command sent to the device requires answering a prompt, it is possible to pass
-      a dict containing command, answer and prompt. Common answers are 'y' or "\\r"
-      (carriage return, must be double quotes). Refer below examples.
+    - Commands may be represented either as simple strings or as dictionaries as described below.
+      Refer to the Examples setion for some common uses.
     required: true
     type: list
     elements: raw
@@ -168,26 +167,35 @@ EXAMPLES = """
     - command: show version
       output: json
 
-- name: using cli transport, check whether the switch is in maintenance mode
+- name: check whether the switch is in maintenance mode
   arista.eos.eos_command:
     commands: show maintenance
     wait_for: result[0] contains 'Under Maintenance'
 
-- name: using cli transport, check whether the switch is in maintenance mode using
-    json output
+- name: check whether the switch is in maintenance mode using json output
   arista.eos.eos_command:
-    commands: show maintenance | json
+    commands:
+    - command: show maintenance
+      output: json
     wait_for: result[0].units.System.state eq 'underMaintenance'
 
-- name: using eapi transport check whether the switch is in maintenance, with 8 retries
+- name: check whether the switch is in maintenance, with 8 retries
     and 2 second interval between retries
   arista.eos.eos_command:
     commands: show maintenance
     wait_for: result[0]['units']['System']['state'] eq 'underMaintenance'
     interval: 2
     retries: 8
-    provider:
-      transport: eapi
+
+- name: run a command that requires a confirmation. Note that prompt
+    takes regexes, and so strings containing characters like brackets
+    need to be escaped.
+  arista.eos.eos_command:
+    commands:
+    - command: reload power
+      prompt: "\[confirm\]"
+      answer: y
+      newline: false
 """
 
 RETURN = """

--- a/plugins/modules/eos_logging.py
+++ b/plugins/modules/eos_logging.py
@@ -18,7 +18,7 @@ version_added: 1.0.0
 deprecated:
   alternative: eos_logging_global
   why: Updated module released with more functionality.
-  removed_at_date: '2023-09-01'
+  removed_at_date: '2024-01-01'
 notes:
 - Tested against Arista EOS 4.24.6F
 options:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Is it possible to do this with a doc_fragment instead?

We should also probably rework the documentation of `commands` itself as well

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_command