### PR TITLE
Enable eos_bgp_global access_group take both IPv4 and IPv6 groups

### DIFF
--- a/changelogs/fragments/bgp_global_access_group_list.yaml
+++ b/changelogs/fragments/bgp_global_access_group_list.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Changed access_group parameter to type list, to enable multiple access-groups configuration.

--- a/docs/arista.eos.eos_bgp_global_module.rst
+++ b/docs/arista.eos.eos_bgp_global_module.rst
@@ -55,7 +55,8 @@ Parameters
                     <b>access_group</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">dictionary</span>
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
                     </div>
                 </td>
                 <td>
@@ -3730,7 +3731,7 @@ Parameters
                     <b>access_group</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">dictionary</span>
+                        <span style="color: purple">list</span>
                     </div>
                 </td>
                 <td>

--- a/docs/arista.eos.eos_bgp_global_module.rst
+++ b/docs/arista.eos.eos_bgp_global_module.rst
@@ -3732,6 +3732,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
                     </div>
                 </td>
                 <td>
@@ -3772,7 +3773,7 @@ Parameters
                 </td>
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    <li>ip</li>
+                                    <li>ipv4</li>
                                     <li>ipv6</li>
                         </ul>
                 </td>

--- a/docs/arista.eos.eos_bgp_module.rst
+++ b/docs/arista.eos.eos_bgp_module.rst
@@ -16,7 +16,7 @@ Version added: 1.0.0
 
 DEPRECATED
 ----------
-:Removed in collection release after 2023-01-29
+:Removed in collection release after 2023-01-01
 :Why: Updated module released with more functionality.
 :Alternative: eos_bgp_global
 
@@ -976,7 +976,7 @@ Status
 ------
 
 
-- This module will be removed in a release after 2023-01-29. *[deprecated]*
+- This module will be removed in version . *[deprecated]*
 - For more information see `DEPRECATED`_.
 
 

--- a/docs/arista.eos.eos_eapi_module.rst
+++ b/docs/arista.eos.eos_eapi_module.rst
@@ -568,7 +568,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>Hash of URL endpoints eAPI is listening on per interface</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;Management1&#x27;: [&#x27;http://172.26.10.1:80&#x27;]}</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AnsibleMapping([(&#x27;Management1&#x27;, [&#x27;http://172.26.10.1:80&#x27;])])</div>
                 </td>
             </tr>
     </table>

--- a/docs/arista.eos.eos_interface_module.rst
+++ b/docs/arista.eos.eos_interface_module.rst
@@ -823,7 +823,7 @@ Status
 ------
 
 
-- This module will be removed in a release after 2022-06-01. *[deprecated]*
+- This module will be removed in version . *[deprecated]*
 - For more information see `DEPRECATED`_.
 
 

--- a/docs/arista.eos.eos_l2_interface_module.rst
+++ b/docs/arista.eos.eos_l2_interface_module.rst
@@ -583,7 +583,7 @@ Status
 ------
 
 
-- This module will be removed in a release after 2022-06-01. *[deprecated]*
+- This module will be removed in version . *[deprecated]*
 - For more information see `DEPRECATED`_.
 
 

--- a/docs/arista.eos.eos_l3_interface_module.rst
+++ b/docs/arista.eos.eos_l3_interface_module.rst
@@ -524,7 +524,7 @@ Status
 ------
 
 
-- This module will be removed in a release after 2022-06-01. *[deprecated]*
+- This module will be removed in version . *[deprecated]*
 - For more information see `DEPRECATED`_.
 
 

--- a/docs/arista.eos.eos_linkagg_module.rst
+++ b/docs/arista.eos.eos_linkagg_module.rst
@@ -587,7 +587,7 @@ Status
 ------
 
 
-- This module will be removed in a release after 2022-06-01. *[deprecated]*
+- This module will be removed in version . *[deprecated]*
 - For more information see `DEPRECATED`_.
 
 

--- a/docs/arista.eos.eos_logging_module.rst
+++ b/docs/arista.eos.eos_logging_module.rst
@@ -16,7 +16,7 @@ Version added: 1.0.0
 
 DEPRECATED
 ----------
-:Removed in collection release after 2023-09-01
+:Removed in collection release after 2024-01-01
 :Why: Updated module released with more functionality.
 :Alternative: eos_logging_global
 
@@ -617,7 +617,7 @@ Status
 ------
 
 
-- This module will be removed in a release after 2023-09-01. *[deprecated]*
+- This module will be removed in version . *[deprecated]*
 - For more information see `DEPRECATED`_.
 
 

--- a/docs/arista.eos.eos_static_route_module.rst
+++ b/docs/arista.eos.eos_static_route_module.rst
@@ -543,7 +543,7 @@ Status
 ------
 
 
-- This module will be removed in a release after 2022-06-01. *[deprecated]*
+- This module will be removed in version . *[deprecated]*
 - For more information see `DEPRECATED`_.
 
 

--- a/docs/arista.eos.eos_vlan_module.rst
+++ b/docs/arista.eos.eos_vlan_module.rst
@@ -613,7 +613,7 @@ Status
 ------
 
 
-- This module will be removed in a release after 2022-06-01. *[deprecated]*
+- This module will be removed in version . *[deprecated]*
 - For more information see `DEPRECATED`_.
 
 

--- a/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
@@ -465,6 +465,18 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                     "elements": "dict",
                     "type": "list",
                     "options": {
+                        "access_group": {
+                            "elements": "dict",
+                            "type": "list",
+                            "options": {
+                                "direction": {"type": "str"},
+                                "afi": {
+                                    "type": "str",
+                                    "choices": ["ipv4", "ipv6"],
+                                },
+                                "acl_name": {"type": "str"},
+                            },
+                        },
                         "router_id": {"type": "str"},
                         "vrf": {"type": "str"},
                         "route_target": {
@@ -892,17 +904,6 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                             },
                         },
                         "shutdown": {"type": "bool"},
-                        "access_group": {
-                            "type": "dict",
-                            "options": {
-                                "direction": {"type": "str"},
-                                "afi": {
-                                    "type": "str",
-                                    "choices": ["ip", "ipv6"],
-                                },
-                                "acl_name": {"type": "str"},
-                            },
-                        },
                         "graceful_restart_helper": {"type": "bool"},
                         "ucmp": {
                             "type": "dict",
@@ -956,7 +957,8 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                     },
                 },
                 "access_group": {
-                    "type": "dict",
+                    "elements": "dict",
+                    "type": "list",
                     "options": {
                         "direction": {"type": "str"},
                         "afi": {"type": "str", "choices": ["ipv4", "ipv6"]},

--- a/plugins/module_utils/network/eos/config/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/config/bgp_global/bgp_global.py
@@ -52,7 +52,6 @@ class Bgp_global(ResourceModule):
             "distance",
             "graceful_restart",
             "graceful_restart_helper",
-            "acccess_group",
             "maximum_paths",
             "monitoring",
             "route_target",
@@ -352,7 +351,12 @@ class Bgp_global(ResourceModule):
                 )
 
     def _compare_lists(self, want, have):
-        for attrib in ["redistribute", "network", "aggregate_address"]:
+        for attrib in [
+            "redistribute",
+            "network",
+            "aggregate_address",
+            "access_group",
+        ]:
             wdict = want.pop(attrib, {})
             hdict = have.pop(attrib, {})
             for key, entry in iteritems(wdict):
@@ -381,6 +385,12 @@ class Bgp_global(ResourceModule):
                 for entry in proc.get("aggregate_address", []):
                     agg_dict.update({entry["address"]: entry})
                 proc["aggregate_address"] = agg_dict
+
+            if "access_group" in proc:
+                access_dict = {}
+                for entry in proc.get("access_group", []):
+                    access_dict.update({entry["afi"]: entry})
+                proc["access_group"] = access_dict
 
             if "redistribute" in proc:
                 redis_dict = {}

--- a/plugins/module_utils/network/eos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/eos/rm_templates/bgp_global.py
@@ -150,10 +150,8 @@ def _tmplt_bgp_params(config_data):
     elif config_data["bgp_params"].get("log_neighbor_changes"):
         command += " log-neighbor-changes"
     elif config_data["bgp_params"].get("missing_policy"):
-        command += (
-            " missing-policy direction {direction} action {action}".format(
-                **config_data["bgp_params"]["missing_policy"]
-            )
+        command += " missing-policy direction {direction} action {action}".format(
+            **config_data["bgp_params"]["missing_policy"]
         )
     elif config_data["bgp_params"].get("monitoring"):
         command += " monitoring"
@@ -224,15 +222,13 @@ def _tmplt_bgp_graceful_restart_helper(config_data):
 
 
 def _tmplt_bgp_access_group(config_data):
-    if config_data["access_group"].get("afi") == "ipv4":
+    if config_data.get("afi") == "ipv4":
         afi = "ip"
     else:
         afi = "ipv6"
-    command = afi + " access-group {acl_name}".format(
-        **config_data["access_group"]
-    )
-    if config_data["access_group"].get("direction"):
-        command += " {direction}".format(**config_data["access_group"])
+    command = afi + " access-group {acl_name}".format(**config_data)
+    if config_data.get("direction"):
+        command += " {direction}".format(**config_data)
     return command
 
 
@@ -1459,7 +1455,7 @@ class Bgp_globalTemplate(NetworkTemplate):
             },
         },
         {
-            "name": "acccess_group",
+            "name": "access_group",
             "getval": re.compile(
                 r"""
                 \s*(?P<afi>ip|ipv6)
@@ -1474,11 +1470,13 @@ class Bgp_globalTemplate(NetworkTemplate):
             "result": {
                 "vrfs": {
                     '{{ "vrf_" + vrf|d() }}': {
-                        "access_group": {
-                            "afi": "{{ ipv4 if afi == 'ip'  else afi }}",
-                            "acl_name": "{{ acl_name }}",
-                            "direction": "{{ direction }}",
-                        }
+                        "access_group": [
+                            {
+                                "afi": "{{ ipv4 if afi == 'ip'  else afi }}",
+                                "acl_name": "{{ acl_name }}",
+                                "direction": "{{ direction }}",
+                            }
+                        ]
                     }
                 }
             },

--- a/plugins/module_utils/network/eos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/eos/rm_templates/bgp_global.py
@@ -150,8 +150,10 @@ def _tmplt_bgp_params(config_data):
     elif config_data["bgp_params"].get("log_neighbor_changes"):
         command += " log-neighbor-changes"
     elif config_data["bgp_params"].get("missing_policy"):
-        command += " missing-policy direction {direction} action {action}".format(
-            **config_data["bgp_params"]["missing_policy"]
+        command += (
+            " missing-policy direction {direction} action {action}".format(
+                **config_data["bgp_params"]["missing_policy"]
+            )
         )
     elif config_data["bgp_params"].get("monitoring"):
         command += " monitoring"

--- a/plugins/modules/eos_bgp_global.py
+++ b/plugins/modules/eos_bgp_global.py
@@ -951,12 +951,12 @@ options:
             access_group:
               description: ip/ipv6 access list configuration.
               type: list
-              elemets: dict
+              elements: dict
               suboptions:
                 afi:
                   description: Specify ip/ipv6.
                   type: str
-                  choices: ['ip', 'ipv6']
+                  choices: ['ipv4', 'ipv6']
                 acl_name:
                   description: access list name.
                   type: str

--- a/plugins/modules/eos_bgp_global.py
+++ b/plugins/modules/eos_bgp_global.py
@@ -279,7 +279,8 @@ options:
           type: bool
         access_group:
           description: ip/ipv6 access list configuration.
-          type: dict
+          type: list
+          elements: dict
           suboptions:
             afi:
               description: Specify ip/ipv6.
@@ -949,7 +950,8 @@ options:
               type: bool
             access_group:
               description: ip/ipv6 access list configuration.
-              type: dict
+              type: list
+              elemets: dict
               suboptions:
                 afi:
                   description: Specify ip/ipv6.

--- a/tests/unit/modules/network/eos/test_eos_bgp_global.py
+++ b/tests/unit/modules/network/eos/test_eos_bgp_global.py
@@ -302,6 +302,10 @@ class TestEosBgpglobalModule(TestEosModule):
                     ],
                     redistribute=[dict(protocol="isis", isis_level="level-2")],
                     route_target=dict(action="export", target="44:22"),
+                    access_group=[
+                        dict(afi="ipv6", acl_name="acl01", direction="out"),
+                        dict(afi="ipv4", acl_name="acl02", direction="out"),
+                    ],
                 ),
                 state="replaced",
             )
@@ -314,6 +318,8 @@ class TestEosBgpglobalModule(TestEosModule):
             "network 10.1.0.0/16",
             "default-metric 433",
             "route-target export 44:22",
+            "ip access-group acl02 out",
+            "ipv6 access-group acl01 out",
             "no timers bgp 44 100",
             "no ucmp link-bandwidth recursive",
             "no neighbor peer1 peer group",
@@ -730,9 +736,9 @@ class TestEosBgpglobalModule(TestEosModule):
                         enforce_first_as=True,
                         host_routes=True,
                     ),
-                    access_group=dict(
-                        afi="ipv6", acl_name="acl01", direction="out"
-                    ),
+                    access_group=[
+                        dict(afi="ipv6", acl_name="acl01", direction="out")
+                    ],
                 ),
                 state="rendered",
             )


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #281 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
