### PR TITLE
Skip irrelevant configs while gathering bgp af facts

### DIFF
--- a/changelogs/fragments/skip_unwanted_configs_bgp_af.yaml
+++ b/changelogs/fragments/skip_unwanted_configs_bgp_af.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Add logic to skip unwanted configs from running-config, to collect bgp af facts.

--- a/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
@@ -72,6 +72,11 @@ class Bgp_afFacts(object):
         vrf_set = ""
         start = False
         for bgp_line in data.splitlines():
+            match_bgp = re.search(
+                r"router (.*) \S+$", bgp_line, flags=re.IGNORECASE
+            )
+            if match_bgp and match_bgp.group(1) != "bgp":
+                break
             if "router bgp" in bgp_line:
                 bgp_af_config.append(bgp_line)
             vrf_present = re.search(r"vrf\s\S+", bgp_line)

--- a/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
@@ -49,7 +49,9 @@ class Bgp_afFacts(object):
         """Wrapper method for `connection.get()`
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
-        return connection.get("show running-config | section router\sbgp ") # noqa: E605
+        return connection.get(
+            "show running-config | section router\sbgp "
+        )  # noqa: W605
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_af network resource

--- a/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
@@ -49,7 +49,7 @@ class Bgp_afFacts(object):
         """Wrapper method for `connection.get()`
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
-        return connection.get("show running-config | section bgp ")
+        return connection.get("show running-config | section router\sbgp ")
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_af network resource
@@ -72,11 +72,6 @@ class Bgp_afFacts(object):
         vrf_set = ""
         start = False
         for bgp_line in data.splitlines():
-            match_bgp = re.search(
-                r"router (.*) \S+$", bgp_line, flags=re.IGNORECASE
-            )
-            if match_bgp and match_bgp.group(1) != "bgp":
-                break
             if "router bgp" in bgp_line:
                 bgp_af_config.append(bgp_line)
             vrf_present = re.search(r"vrf\s\S+", bgp_line)

--- a/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
@@ -49,7 +49,7 @@ class Bgp_afFacts(object):
         """Wrapper method for `connection.get()`
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
-        return connection.get("show running-config | section router\sbgp ")
+        return connection.get("show running-config | section router\sbgp ") # noqa: E605
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_af network resource

--- a/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/eos/facts/bgp_address_family/bgp_address_family.py
@@ -49,9 +49,7 @@ class Bgp_afFacts(object):
         """Wrapper method for `connection.get()`
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
-        return connection.get(
-            "show running-config | section router\sbgp "
-        )  # noqa: W605
+        return connection.get("show running-config | section router\\sbgp ")
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_af network resource

--- a/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
@@ -37,7 +37,7 @@ class Bgp_globalFacts(object):
         """Wrapper method for `connection.get()`
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
-        return connection.get("show running-config | section router\sbgp ")
+        return connection.get("show running-config | section router\sbgp ") # noqa: E605
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_global network resource

--- a/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
@@ -37,9 +37,7 @@ class Bgp_globalFacts(object):
         """Wrapper method for `connection.get()`
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
-        return connection.get(
-            "show running-config | section router\sbgp "
-        )  # noqa: W605
+        return connection.get("show running-config | section router\\sbgp ")
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_global network resource

--- a/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
@@ -37,7 +37,9 @@ class Bgp_globalFacts(object):
         """Wrapper method for `connection.get()`
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
-        return connection.get("show running-config | section router\sbgp ") # noqa: E605
+        return connection.get(
+            "show running-config | section router\sbgp "
+        )  # noqa: W605
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_global network resource

--- a/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
@@ -37,7 +37,7 @@ class Bgp_globalFacts(object):
         """Wrapper method for `connection.get()`
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
-        return connection.get("show running-config | section bgp ")
+        return connection.get("show running-config | section router\sbgp ")
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_global network resource

--- a/tests/unit/modules/network/eos/fixtures/eos_bgp_af_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_bgp_af_config.cfg
@@ -21,16 +21,3 @@ router bgp 10
       address-family ipv6
          redistribute isis level-2
 !
-router isis RA
-   log-adjacency-changes
-   max-lsp-lifetime 4000
-   set-overload-bit on-startup wait-for-bgp
-   spf-interval 5 50 200
-   authentication mode md5
-   !
-   address-family ipv4 unicast
-      maximum-paths 6
-      redistribute isis level-1 into level-2 route-map IPV4-DENY-ISIS-L1-TO-L2
-      bfd all-interfaces
-   !
-

--- a/tests/unit/modules/network/eos/fixtures/eos_bgp_af_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_bgp_af_config.cfg
@@ -20,4 +20,17 @@ router bgp 10
       !
       address-family ipv6
          redistribute isis level-2
+!
+router isis RA
+   log-adjacency-changes
+   max-lsp-lifetime 4000
+   set-overload-bit on-startup wait-for-bgp
+   spf-interval 5 50 200
+   authentication mode md5
+   !
+   address-family ipv4 unicast
+      maximum-paths 6
+      redistribute isis level-1 into level-2 route-map IPV4-DENY-ISIS-L1-TO-L2
+      bfd all-interfaces
+   !
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands = {posargs}
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125,E402,W503,W504,W605
+ignore = E123,E125,E402,W503,W504
 max-line-length = 160
 builtins = _
 exclude = .git,.tox,tests/unit/compat/

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands = {posargs}
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125,E402,W503,W504
+ignore = E123,E125,E402,W503,W504,W605
 max-line-length = 160
 builtins = _
 exclude = .git,.tox,tests/unit/compat/


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
Fixes #308

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

'show running-config | section bgp' lists all the available bgp configs on the device. The assumption that only configs under "router bgp <>" will be listed is broken. Fixed this by adding logic to skip the other irrelevant configs.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
