### PR TITLE
Fix invalid example in eos_l2_interfaces

### DIFF
--- a/changelogs/fragments/fix_documentation_eos_l2_interfaces.yml
+++ b/changelogs/fragments/fix_documentation_eos_l2_interfaces.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Fixed an invalid parameter used in example for eos_l2_interfaces"

--- a/plugins/modules/eos_l2_interfaces.py
+++ b/plugins/modules/eos_l2_interfaces.py
@@ -185,7 +185,7 @@ EXAMPLES = """
       mode: trunk
       trunk:
         native_vlan: 20
-        trunk_vlans: 5-10, 15
+        trunk_allowed_vlans: 5-10, 15
     state: replaced
 
 # After state:


### PR DESCRIPTION
##### SUMMARY
There is an invalid parameter used in example for eos_l2_interfaces

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
eos_l2_interfaces

##### ADDITIONAL INFORMATION
There was an error in example which ends up in documentation causing documentation to be incorrect. This PR fixes one such case