### PR TITLE
Fix for issue #329: Formatting in protocol_options causes errors...

### DIFF
--- a/changelogs/fragments/fix_eos_acls_protocol_options.yml
+++ b/changelogs/fragments/fix_eos_acls_protocol_options.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - arista.eos.eos_acls - fixed issue where protcol_options were rendered to command line using the key _underscore_ value rather than the hyphen nominclature.
+  - arista.eos.eos_acls - fixed issue that would cause a key value error on `aces` element when no ACEs exist in the access-list.

--- a/plugins/module_utils/network/eos/config/acls/acls.py
+++ b/plugins/module_utils/network/eos/config/acls/acls.py
@@ -395,7 +395,7 @@ def set_commands(want, have):
                         if wacl["name"] == hacl["name"]:
                             want_aces = wacl["aces"]
                             for wace in wacl["aces"]:
-                                for hace in hacl["aces"]:
+                                for hace in hacl.get("aces", []):
                                     if (
                                         "sequence" in wace.keys()
                                         and "sequence" in hace.keys()
@@ -493,7 +493,7 @@ def add_commands(want):
                     for op, val in ace["source"]["port_protocol"].items():
                         if val.isdigit():
                             val = socket.getservbyport(int(val))
-                        command = command + " " + op + " " + val
+                        command = command + " " + op + " " + val.replace("_", "-")
             if "destination" in ace.keys():
                 if "any" in ace["destination"].keys():
                     command = command + " any"
@@ -518,13 +518,13 @@ def add_commands(want):
                             + " "
                             + op
                             + " "
-                            + ace["destination"]["port_protocol"][op]
+                            + ace["destination"]["port_protocol"][op].replace("_", "-")
                         )
             if "protocol_options" in ace.keys():
                 for proto in ace["protocol_options"].keys():
                     if proto == "icmp" or proto == "icmpv6":
                         for icmp_msg in ace["protocol_options"][proto].keys():
-                            command = command + " " + icmp_msg
+                            command = command + " " + icmp_msg.replace("_", "-")
                     elif proto == "ip" or proto == "ipv6":
                         command = (
                             command

--- a/plugins/module_utils/network/eos/config/acls/acls.py
+++ b/plugins/module_utils/network/eos/config/acls/acls.py
@@ -493,7 +493,9 @@ def add_commands(want):
                     for op, val in ace["source"]["port_protocol"].items():
                         if val.isdigit():
                             val = socket.getservbyport(int(val))
-                        command = command + " " + op + " " + val.replace("_", "-")
+                        command = (
+                            command + " " + op + " " + val.replace("_", "-")
+                        )
             if "destination" in ace.keys():
                 if "any" in ace["destination"].keys():
                     command = command + " any"
@@ -518,13 +520,17 @@ def add_commands(want):
                             + " "
                             + op
                             + " "
-                            + ace["destination"]["port_protocol"][op].replace("_", "-")
+                            + ace["destination"]["port_protocol"][op].replace(
+                                "_", "-"
+                            )
                         )
             if "protocol_options" in ace.keys():
                 for proto in ace["protocol_options"].keys():
                     if proto == "icmp" or proto == "icmpv6":
                         for icmp_msg in ace["protocol_options"][proto].keys():
-                            command = command + " " + icmp_msg.replace("_", "-")
+                            command = (
+                                command + " " + icmp_msg.replace("_", "-")
+                            )
                     elif proto == "ip" or proto == "ipv6":
                         command = (
                             command


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #329 
 [√] Added replace statement to convert underscores to hyphens. It appears all syntax for Arista protocol options and named ports are using the hyphen nomenclature.
[√] Additional commit to fix error when an access list does not have any ACEs in it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
arista.eos.eos_acls

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
