### PR TITLE
Remove warning for default value of gather_subset from eos_facts

### DIFF
--- a/changelogs/fragments/eos_facts_remove_warning.yaml
+++ b/changelogs/fragments/eos_facts_remove_warning.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "`eos_facts` - Remove warning regarding default value for gather_subset"

--- a/plugins/modules/eos_facts.py
+++ b/plugins/modules/eos_facts.py
@@ -195,10 +195,6 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec, supports_check_mode=True
     )
-    warnings = [
-        "default value for `gather_subset` "
-        "will be changed to `min` from `!config` v2.11 onwards"
-    ]
 
     ansible_facts = {}
     if module.params.get("available_network_resources"):


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The warning is no more needed because the default value has been changed by https://github.com/ansible-collections/arista.eos/pull/343

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
