### PR TITLE
Raise precision of cliconf sessions

### DIFF
--- a/changelogs/fragments/fast_sessions.yaml
+++ b/changelogs/fragments/fast_sessions.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Automatiaclly named sessions (ansible_XXXXXXXXX) now use two digits of sub-second
+    precision (if available). This is to work around tasks reusing a session if the previous task
+    completed very quickly.

--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -128,7 +128,7 @@ class Cliconf(CliconfBase):
         resp = {}
         session = None
         if self.supports_sessions():
-            session = "ansible_%s" % int(time.time())
+            session = "ansible_%.2f" % time.time()
             resp.update({"session": session})
             self.send_command("configure session %s" % session)
             if replace:

--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -54,12 +54,14 @@ options:
 """
 
 import json
-import time
 import re
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import Mapping
+from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
+    session_name,
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
 )
@@ -128,7 +130,7 @@ class Cliconf(CliconfBase):
         resp = {}
         session = None
         if self.supports_sessions():
-            session = "ansible_%d" % (time.time() * 100)
+            session = session_name()
             resp.update({"session": session})
             self.send_command("configure session %s" % session)
             if replace:

--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -128,7 +128,7 @@ class Cliconf(CliconfBase):
         resp = {}
         session = None
         if self.supports_sessions():
-            session = "ansible_%.2f" % time.time()
+            session = "ansible_%d" % (time.time() * 100)
             resp.update({"session": session})
             self.send_command("configure session %s" % session)
             if replace:

--- a/plugins/httpapi/eos.py
+++ b/plugins/httpapi/eos.py
@@ -161,7 +161,7 @@ class HttpApi(HttpApiBase):
 
         session = None
         if self.supports_sessions():
-            session = "ansible_%.2f" % time.time()
+            session = "ansible_%d" % (time.time() * 100)
             candidate = ["configure session %s" % session] + candidate
         else:
             candidate = ["configure"] + candidate

--- a/plugins/httpapi/eos.py
+++ b/plugins/httpapi/eos.py
@@ -26,11 +26,13 @@ options:
 """
 
 import json
-import time
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import ConnectionError
+from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
+    session_name,
+)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     to_list,
 )
@@ -161,7 +163,7 @@ class HttpApi(HttpApiBase):
 
         session = None
         if self.supports_sessions():
-            session = "ansible_%d" % (time.time() * 100)
+            session = session_name()
             candidate = ["configure session %s" % session] + candidate
         else:
             candidate = ["configure"] + candidate

--- a/plugins/httpapi/eos.py
+++ b/plugins/httpapi/eos.py
@@ -161,7 +161,7 @@ class HttpApi(HttpApiBase):
 
         session = None
         if self.supports_sessions():
-            session = "ansible_%d" % int(time.time())
+            session = "ansible_%.2f" % time.time()
             candidate = ["configure session %s" % session] + candidate
         else:
             candidate = ["configure"] + candidate

--- a/plugins/module_utils/network/eos/eos.py
+++ b/plugins/module_utils/network/eos/eos.py
@@ -123,6 +123,11 @@ def transform_commands(module):
     return transform(module.params["commands"])
 
 
+def session_name():
+    """Generate a unique string to be used as a configuration session name."""
+    return "ansible_%d" % (time.time() * 100)
+
+
 class Cli:
     def __init__(self, module):
         self._module = module
@@ -413,7 +418,7 @@ class LocalEapi:
                 result = {"changed": True}
                 return result
 
-        session = "ansible_%s" % int(time.time())
+        session = session_name()
         result = {"session": session}
         commands = ["configure session %s" % session]
 
@@ -628,7 +633,7 @@ class HttpApi:
         fallback to using configure() to load the commands.  If that happens,
         there will be no returned diff or session values
         """
-        session = "ansible_%s" % int(time.time())
+        session = session_name()
         result = {"session": session}
         banner_cmd = None
         banner_input = []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
If a task runs quickly enough, the next task may start in the same second. As we generate session names based on `time.time()`, this will mean that the next task will also try to reuse the same session name and fail. This PR raises the precision used for session names to two decimal places to avoid that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cliconf
httpapi

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
