### PR TITLE
Commit timer support for Arista EOS

### DIFF
--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -39,6 +39,14 @@ options:
     - name: ANSIBLE_EOS_USE_SESSIONS
     vars:
     - name: ansible_eos_use_sessions
+  eos_session_name:
+    type: string
+    description:
+    - Specifies if a custom session name should be used.
+    env:
+    - name: ANSIBLE_EOS_SESSION_NAME
+    vars:
+    - name: ansible_eos_session_name
   config_commands:
     description:
     - Specifies a list of commands that can make configuration changes
@@ -130,7 +138,11 @@ class Cliconf(CliconfBase):
         resp = {}
         session = None
         if self.supports_sessions():
-            session = session_name()
+            custom_session_name = self.get_option('ansible_eos_session_name')
+            if custom_session_name:
+                session = custom_session_name
+            else:
+                session = session_name()
             resp.update({"session": session})
             self.send_command("configure session %s" % session)
             if replace:

--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -164,6 +164,11 @@ class Cliconf(CliconfBase):
                     self.discard_changes(session)
                     raise AnsibleConnectionFailure(e.message)
 
+            # commit timer commands put the CLI out of config mode,
+            # so put it back into configure mode for subsequent commands
+            if cmd.startswith("commit timer"):
+                self.send_command("configure")
+
         resp["request"] = requests
         resp["response"] = results
         if self.supports_sessions():

--- a/plugins/httpapi/eos.py
+++ b/plugins/httpapi/eos.py
@@ -23,6 +23,14 @@ options:
     - name: ANSIBLE_EOS_USE_SESSIONS
     vars:
     - name: ansible_eos_use_sessions
+  eos_session_name:
+    type: string
+    description:
+    - Specifies if a custom session name should be used.
+    env:
+    - name: ANSIBLE_EOS_SESSION_NAME
+    vars:
+    - name: ansible_eos_session_name
 """
 
 import json
@@ -163,7 +171,11 @@ class HttpApi(HttpApiBase):
 
         session = None
         if self.supports_sessions():
-            session = session_name()
+            custom_session_name = self.get_option('ansible_eos_session_name')
+            if custom_session_name:
+                session = custom_session_name
+            else:
+                session = session_name()
             candidate = ["configure session %s" % session] + candidate
         else:
             candidate = ["configure"] + candidate


### PR DESCRIPTION
This PR has a couple of goals:

- [x] Gracefully handle cases where users use `commit timer` in their templates or `eos_config` calls
- [x] Allow the session name that Ansible uses to be configurable
- [ ] Create a behavior similar to Juniper's [`confirm_commit`](https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/junos_config_module.html#parameter-confirm_commit) feature, where you push a candidate config, then confirm it.
