### PR TITLE
Deprecate module arg vrf in favor of vrfs

### DIFF
--- a/plugins/modules/eos_eapi.py
+++ b/plugins/modules/eos_eapi.py
@@ -238,7 +238,7 @@ def validate_vrfs(value, module):
     lines = out[0].strip().splitlines()[3:]
     for line in lines:
         if not line:
-            continuess
+            continues
         splitted_line = re.split(r"\s{2,}", line.strip())
         if len(splitted_line) > 2:
             configured_vrfs.append(splitted_line[0])


### PR DESCRIPTION
##### SUMMARY
This commit remove the use of the singular 'vrf' and adds the use of 'vrfs'

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
eos_eapi

##### ADDITIONAL INFORMATION
This commit remove the use of the singular 'vrf' and adds the use of 'vrfs'

The singular VRF posed a few issues.  First is was impossible to define more than 1 VRF without creating multiple tasks.  This in turn made the module not idempotent.  This reconfiguration of the module allows for none ('default') or multiple VRFs to be configured.  Additionally, if multiple VRFs were defined and configured in the API the return of the command 'show management api http-commands | json' has two vrf keys.  One is vrf, the other is vrfs.  vrf appear to alphabetize the configured VRFs and return only the first result.  vrfs returns all configured vrfs.

This module assumes that if the VRF is listed, it should be configured and 'no shutdown' applied as the only options are to 'no shutdown' or 'shutdown' the VRF in the management API configuration.  The module also now removes any VRFs from the management api configuration which are not listed in the playbook.

Additional work would have to be performed in order to add the ability to create comments or access-lists.