### PR TITLE
Add integration tests for eAPI with SSL

### DIFF
--- a/tests/integration/targets/eos_smoke/tests/eapi/command_ssl.yaml
+++ b/tests/integration/targets/eos_smoke/tests/eapi/command_ssl.yaml
@@ -1,0 +1,25 @@
+---
+- name: Test 'show version' via eAPI SSL (should fail with Py3.10 because of default ciphers)
+  ignore_errors: true
+  register: result
+  vars:
+    ansible_httpapi_use_ssl: true
+    ansible_httpapi_validate_certs: false
+  arista.eos.eos_command:
+    commands:
+      - show version
+
+- assert:
+    that:
+      - '"[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure" in result.module_stderr'
+  when: result.failed
+
+- name: Test 'show version' via eAPI SSL when ansible-core >= 2.14 (ansible_httpapi_ciphers=['AES256-SHA'])
+  vars:
+    ansible_httpapi_use_ssl: true
+    ansible_httpapi_validate_certs: false
+    ansible_httpapi_ciphers: ['AES256-SHA']
+  arista.eos.eos_command:
+    commands:
+      - show version
+  when: ansible_version.full is version('2.14.0', '>=')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add integration tests for eAPI with SSL

There is no coverage for SSL with eAPI, which would have shown the SSL Cipher issue introduced with Python 3.10. In Python 3.10 the default ciphers are no longer compatible with current Arista EOS versions, so eAPI connection fail with `[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:997)`.

The issue can be worked around by supplying ciphers manually. Support for this went into `ansible-core` 2.14 and is being implemented in `ansible.netcommon` in https://github.com/ansible-collections/ansible.netcommon/pull/494.

This PR add test cases for regular `eos_command` via eAPI with SSL. The test case is expected to fail with Python3.10 with the error message mentioned above.
For `ansible-core` >= 2.14 another test will run setting the `ansible_httpapi_ciphers` as introduced in the `ansible.netcommon` PR referenced above.

This PR will not pass CI until https://github.com/ansible-collections/ansible.netcommon/pull/494 has been merged, so it will be left in draft until then.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Integration Tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
