### PR TITLE
[fixed]: IPv6 destination address with mixed alphabets did not match.

### DIFF
--- a/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
@@ -140,7 +140,7 @@ class Static_routesFacts(object):
         conf_list = conf.split("\n")
         for conf_elem in conf_list:
             matches = re.findall(
-                r"(ip|ipv6) route ([\d\.\/:]+|vrf) (.+)$",
+                r"(ip|ipv6) route ([\d\.\/:a-f]+|vrf) (.+)$",
                 conf_elem,
             )
             if matches:


### PR DESCRIPTION
##### SUMMARY
IPv6 destination address with only ::/0 or numbers was matched, but IPv6 destination address with mixed alphabets was not matched because there was an omission in the regular expression.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
arista.eos.eos_static_routes module 

##### ADDITIONAL INFORMATION

* Case that could have been handled

```
ipv6 route ::/0 2001:db8::1
```

* Case that could have not been handled

```
ipv6 route 2001:db8::/48 2001:db8::1
```
