### PR TITLE
Update examples for lag_interfaces

### DIFF
--- a/changelogs/fragments/lag_interface_docupdate.yml
+++ b/changelogs/fragments/lag_interface_docupdate.yml
@@ -1,0 +1,3 @@
+---
+doc_changes:
+  - eos_lag_interface - Updated examples for lag_interface module.

--- a/docs/arista.eos.eos_lag_interfaces_module.rst
+++ b/docs/arista.eos.eos_lag_interfaces_module.rst
@@ -196,7 +196,7 @@ Examples
     - name: Merge provided LAG attributes with existing device configuration
       arista.eos.eos_lag_interfaces:
         config:
-          - name: 5
+          - name: Port-Channel5
             members:
               - member: Ethernet2
                 mode: "on"
@@ -225,7 +225,7 @@ Examples
     - name: Replace all device configuration of specified LAGs with provided configuration
       arista.eos.eos_lag_interfaces:
         config:
-          - name: 5
+          - name: Port-Channel5
             members:
               - member: Ethernet2
                 mode: "on"
@@ -253,7 +253,7 @@ Examples
     - name: Override all device configuration of all LAG attributes with provided configuration
       arista.eos.eos_lag_interfaces:
         config:
-          - name: 10
+          - name: Port-Channel10
             members:
               - member: Ethernet2
                 mode: "on"
@@ -282,7 +282,7 @@ Examples
     - name: Delete LAG attributes of the given interfaces.
       arista.eos.eos_lag_interfaces:
         config:
-          - name: 5
+          - name: Port-Channel5
             members:
               - member: Ethernet1
         state: deleted
@@ -310,7 +310,7 @@ Examples
 
     # Output:
     #   parsed:
-    #     - name: 5
+    #     - name: Port-Channel5
     #       members:
     #         - member: Ethernet2
     #           mode: "on"
@@ -322,7 +322,7 @@ Examples
     - name: Use Rendered to convert the structured data to native config
       arista.eos.eos_lag_interfaces:
         config:
-          - name: 5
+          - name: Port-Channel5
             members:
               - member: Ethernet2
                 mode: "on"
@@ -355,7 +355,7 @@ Examples
 
     # Output:
     #   gathered:
-    #     - name: 5
+    #     - name: Port-Channel5
     #       members:
     #         - member: Ethernet2
     #           mode: on

--- a/plugins/modules/eos_lag_interfaces.py
+++ b/plugins/modules/eos_lag_interfaces.py
@@ -112,7 +112,7 @@ EXAMPLES = """
 - name: Merge provided LAG attributes with existing device configuration
   arista.eos.eos_lag_interfaces:
     config:
-      - name: 5
+      - name: Port-Channel5
         members:
           - member: Ethernet2
             mode: "on"
@@ -141,7 +141,7 @@ EXAMPLES = """
 - name: Replace all device configuration of specified LAGs with provided configuration
   arista.eos.eos_lag_interfaces:
     config:
-      - name: 5
+      - name: Port-Channel5
         members:
           - member: Ethernet2
             mode: "on"
@@ -169,7 +169,7 @@ EXAMPLES = """
 - name: Override all device configuration of all LAG attributes with provided configuration
   arista.eos.eos_lag_interfaces:
     config:
-      - name: 10
+      - name: Port-Channel10
         members:
           - member: Ethernet2
             mode: "on"
@@ -198,7 +198,7 @@ EXAMPLES = """
 - name: Delete LAG attributes of the given interfaces.
   arista.eos.eos_lag_interfaces:
     config:
-      - name: 5
+      - name: Port-Channel5
         members:
           - member: Ethernet1
     state: deleted
@@ -226,7 +226,7 @@ EXAMPLES = """
 
 # Output:
 #   parsed:
-#     - name: 5
+#     - name: Port-Channel5
 #       members:
 #         - member: Ethernet2
 #           mode: "on"
@@ -238,7 +238,7 @@ EXAMPLES = """
 - name: Use Rendered to convert the structured data to native config
   arista.eos.eos_lag_interfaces:
     config:
-      - name: 5
+      - name: Port-Channel5
         members:
           - member: Ethernet2
             mode: "on"
@@ -271,7 +271,7 @@ EXAMPLES = """
 
 # Output:
 #   gathered:
-#     - name: 5
+#     - name: Port-Channel5
 #       members:
 #         - member: Ethernet2
 #           mode: on


### PR DESCRIPTION
##### SUMMARY
Updated the examples for eos_lag_interfaces.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- `eos_lag_interfaces`

##### ADDITIONAL INFORMATION
The `name` attribute in the examples of eos_lag_interfaces was not updated. This pr was opened because of issue #515. Found that `normalize_interface` function takes in the input and normalizes it. It expects input as a string which contains prefix `po`. The examples only had numbers as value.
