### PR TITLE
Return empty lists for static_routes or vlans when not configured

### DIFF
--- a/changelogs/fragments/bugfixes_return_empty_data_structure_for_no_facts.yaml
+++ b/changelogs/fragments/bugfixes_return_empty_data_structure_for_no_facts.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - This fix is needed because static_routes and vlans are not returning anything when resources are not configured.
+  - This got noticed in this issue (https://github.com/network-automation/toolkit/issues/47)
+  - when static_routes and vlans are not confirgured then return empty list.

--- a/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
@@ -96,7 +96,7 @@ class Static_routesFacts(object):
                 if obj:
                     objs.append(obj)
         ansible_facts["ansible_network_resources"].pop("static_routes", None)
-        facts = {}
+        facts = {"static_routes": []}
         if objs:
             facts["static_routes"] = []
             params = utils.validate_config(

--- a/plugins/module_utils/network/eos/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/eos/facts/vlans/vlans.py
@@ -69,7 +69,7 @@ class VlansFacts(object):
                     objs.extend(obj)
 
         ansible_facts["ansible_network_resources"].pop("vlans", None)
-        facts = {}
+        facts = {"vlans": []}
         if objs:
             params = utils.validate_config(
                 self.argument_spec,

--- a/tests/integration/targets/eos_facts/tests/cli/network_facts
+++ b/tests/integration/targets/eos_facts/tests/cli/network_facts
@@ -1,0 +1,15 @@
+---
+- ansible.builtin.debug: msg="START cli/network_resource_facts.yaml on connection={{ ansible_connection }}"
+
+- name: Gather arista network resource facts
+  arista.eos.eos_facts:
+    gather_subset: config
+    gather_network_resources:
+      - 'static_routes'
+  register: result
+
+- name: Assert that  facts gathered was correctly generated
+  ansible.builtin.assert:
+    that:
+      - "result['ansible_facts']['ansible_network_resources']['static_routes'] == []"
+- ansible.builtin.debug: msg="END cli/network_resource_facts.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Return empty lists for static_routes or vlans when not configured
Resolves: 
- https://github.com/ansible-collections/arista.eos/issues/517 
- https://github.com/network-automation/toolkit/issues/47
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- eos_static_routes 
- eos_valns
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- name: Network Facts
  hosts: eos
  collections:
    - arista.eos
  tasks:
    - name: Gather arista eos facts
      arista.eos.eos_facts:
        gather_subset: config
        gather_network_resources: "{{ 'all' }}"

Output: 
        ospf_interfaces:
        - name: Ethernet1
        - name: Ethernet2
        - name: Management0
        - name: Management1
        - name: Vlan100
        ospfv2: {}
        ospfv3: []
        prefix_lists: []
        snmp_server: {}
        static_routes: []
        vlans: []
    changed: false
    failed: false

```
