### PR TITLE
Fix lacp interface configuration cleanup to prevent spill over

### DIFF
--- a/tests/integration/targets/eos_lacp_interfaces/tests/common/deleted.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tests/common/deleted.yaml
@@ -1,4 +1,10 @@
 ---
+- ansible.builtin.debug:
+    msg: START eos_lacp_interfaces deleted integration tests on connection={{
+      ansible_connection }}
+
+- ansible.builtin.include_tasks: _remove_config.yaml
+
 - ansible.builtin.include_tasks: _reset_config.yaml
 
 - ansible.builtin.set_fact:
@@ -7,36 +13,44 @@
     other_config:
       - name: Ethernet2
         timer: fast
+- block:
+    - become: true
+      arista.eos.eos_facts:
+        gather_network_resources: lacp_interfaces
 
-- become: true
-  arista.eos.eos_facts:
-    gather_network_resources: lacp_interfaces
+    - name: Returns vlans to default parameters
+      register: result
+      become: true
+      arista.eos.eos_lacp_interfaces:
+        config: "{{ config }}"
+        state: deleted
 
-- name: Returns vlans to default parameters
-  register: result
-  become: true
-  arista.eos.eos_lacp_interfaces:
-    config: "{{ config }}"
-    state: deleted
+    - ansible.builtin.assert:
+        that:
+          - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.before)
+            == []
 
-- ansible.builtin.assert:
-    that:
-      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.before)
-        == []
+    - become: true
+      arista.eos.eos_facts:
+        gather_network_resources: lacp_interfaces
 
-- become: true
-  arista.eos.eos_facts:
-    gather_network_resources: lacp_interfaces
+    - ansible.builtin.assert:
+        that:
+          - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)
+            == []
 
-- ansible.builtin.assert:
-    that:
-      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)
-        == []
+    - ansible.builtin.set_fact:
+        expected_config: "{{ other_config }}"
 
-- ansible.builtin.set_fact:
-    expected_config: "{{ other_config }}"
+    - ansible.builtin.assert:
+        that:
+          - expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces)
+            == []
 
-- ansible.builtin.assert:
-    that:
-      - expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces)
-        == []
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml
+
+- ansible.builtin.debug:
+    msg:
+      END eos_lacp_interfaces deleted integration tests on connection={{ ansible_connection
+      }}

--- a/tests/integration/targets/eos_lacp_interfaces/tests/common/gathered.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tests/common/gathered.yaml
@@ -4,6 +4,8 @@
       START eos_lacp_interfaces gathered integration tests on connection={{ ansible_connection
       }}
 
+- ansible.builtin.include_tasks: _remove_config.yaml
+
 - ansible.builtin.include_tasks: _reset_config.yaml
 
 - block:
@@ -21,3 +23,10 @@
     - ansible.builtin.assert:
         that:
           - ansible_facts.network_resources.lacp_interfaces == result.gathered
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml
+
+- ansible.builtin.debug:
+    msg:
+      END eos_lacp_interfaces gathered integration tests on connection={{ ansible_connection
+      }}

--- a/tests/integration/targets/eos_lacp_interfaces/tests/common/merged.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tests/common/merged.yaml
@@ -1,4 +1,10 @@
 ---
+- ansible.builtin.debug:
+    msg: START eos_lacp_interfaces merged integration tests on connection={{
+      ansible_connection }}
+
+- ansible.builtin.include_tasks: _remove_config.yaml
+
 - ansible.builtin.include_tasks: _reset_config.yaml
 
 - ansible.builtin.set_fact:
@@ -9,38 +15,47 @@
       - name: Ethernet2
         timer: normal
 
-- become: true
-  arista.eos.eos_facts:
-    gather_network_resources: lacp_interfaces
+- block:
+    - become: true
+      arista.eos.eos_facts:
+        gather_network_resources: lacp_interfaces
 
-- name: Merge provided configuration with device configuration
-  register: result
-  become: true
-  arista.eos.eos_lacp_interfaces:
-    config: "{{ config }}"
-    state: merged
+    - name: Merge provided configuration with device configuration
+      register: result
+      become: true
+      arista.eos.eos_lacp_interfaces:
+        config: "{{ config }}"
+        state: merged
 
-- ansible.builtin.assert:
-    that:
-      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.before)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.before)
+            == []
 
-- become: true
-  arista.eos.eos_facts:
-    gather_network_resources: lacp_interfaces
+    - become: true
+      arista.eos.eos_facts:
+        gather_network_resources: lacp_interfaces
 
-- ansible.builtin.assert:
-    that:
-      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)
+            == []
 
-- ansible.builtin.set_fact:
-    expected_config:
-      - name: Ethernet1
-        port_priority: 30
-        timer: fast
+    - ansible.builtin.set_fact:
+        expected_config:
+          - name: Ethernet1
+            port_priority: 30
+            timer: fast
 
-- ansible.builtin.assert:
-    that:
-      - expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces)
+            == []
+
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml
+
+- ansible.builtin.debug:
+    msg:
+      END eos_lacp_interfaces merged integration tests on connection={{ ansible_connection
+      }}

--- a/tests/integration/targets/eos_lacp_interfaces/tests/common/overridden.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tests/common/overridden.yaml
@@ -1,4 +1,10 @@
 ---
+- ansible.builtin.debug:
+    msg: START eos_lacp_interfaces overridden integration tests on connection={{
+      ansible_connection }}
+
+- ansible.builtin.include_tasks: _remove_config.yaml
+
 - ansible.builtin.include_tasks: _reset_config.yaml
 
 - ansible.builtin.set_fact:
@@ -6,35 +12,44 @@
       - name: Ethernet1
         timer: fast
 
-- become: true
-  arista.eos.eos_facts:
-    gather_network_resources: lacp_interfaces
+- block:
+    - become: true
+      arista.eos.eos_facts:
+        gather_network_resources: lacp_interfaces
 
-- name: Overrides device configuration of all vlans with provided configuration
-  register: result
-  become: true
-  arista.eos.eos_lacp_interfaces:
-    config: "{{ config }}"
-    state: overridden
+    - name: Overrides device configuration of all vlans with provided configuration
+      register: result
+      become: true
+      arista.eos.eos_lacp_interfaces:
+        config: "{{ config }}"
+        state: overridden
 
-- ansible.builtin.assert:
-    that:
-      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.before)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.before)
+            == []
 
-- become: true
-  arista.eos.eos_facts:
-    gather_network_resources: lacp_interfaces
+    - become: true
+      arista.eos.eos_facts:
+        gather_network_resources: lacp_interfaces
 
-- ansible.builtin.assert:
-    that:
-      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)
+            == []
 
-- ansible.builtin.set_fact:
-    expected_config: "{{ config }}"
+    - ansible.builtin.set_fact:
+        expected_config: "{{ config }}"
 
-- ansible.builtin.assert:
-    that:
-      - expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces)
+            == []
+
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml
+
+- ansible.builtin.debug:
+    msg:
+      END eos_lacp_interfaces overridden integration tests on connection={{ ansible_connection
+      }}

--- a/tests/integration/targets/eos_lacp_interfaces/tests/common/replaced.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tests/common/replaced.yaml
@@ -1,4 +1,10 @@
 ---
+- ansible.builtin.debug:
+    msg: START eos_lacp_interfaces replaced integration tests on connection={{
+      ansible_connection }}
+
+- ansible.builtin.include_tasks: _remove_config.yaml
+
 - ansible.builtin.include_tasks: _reset_config.yaml
 
 - ansible.builtin.set_fact:
@@ -10,35 +16,44 @@
       - name: Ethernet2
         timer: fast
 
-- become: true
-  arista.eos.eos_facts:
-    gather_network_resources: lacp_interfaces
+- block:
+    - become: true
+      arista.eos.eos_facts:
+        gather_network_resources: lacp_interfaces
 
-- name: Replaces device configuration of listed vlans with provided configuration
-  register: result
-  become: true
-  arista.eos.eos_lacp_interfaces:
-    config: "{{ config }}"
-    state: replaced
+    - name: Replaces device configuration of listed vlans with provided configuration
+      register: result
+      become: true
+      arista.eos.eos_lacp_interfaces:
+        config: "{{ config }}"
+        state: replaced
 
-- ansible.builtin.assert:
-    that:
-      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.before)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.before)
+            == []
 
-- become: true
-  arista.eos.eos_facts:
-    gather_network_resources: lacp_interfaces
+    - become: true
+      arista.eos.eos_facts:
+        gather_network_resources: lacp_interfaces
 
-- ansible.builtin.assert:
-    that:
-      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(result.after)
+            == []
 
-- ansible.builtin.set_fact:
-    expected_config: "{{ config + other_config }}"
+    - ansible.builtin.set_fact:
+        expected_config: "{{ config + other_config }}"
 
-- ansible.builtin.assert:
-    that:
-      - expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces)
+            == []
+
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml
+
+- ansible.builtin.debug:
+    msg:
+      END eos_lacp_interfaces replaced integration tests on connection={{ ansible_connection
+      }}

--- a/tests/integration/targets/eos_lacp_interfaces/tests/common/rtt.yaml
+++ b/tests/integration/targets/eos_lacp_interfaces/tests/common/rtt.yaml
@@ -1,4 +1,10 @@
 ---
+- ansible.builtin.debug:
+    msg: START eos_lacp_interfaces round trip integration tests on connection={{
+      ansible_connection }}
+
+- ansible.builtin.include_tasks: _remove_config.yaml
+
 - ansible.builtin.include_tasks: _reset_config.yaml
 
 - ansible.builtin.set_fact:
@@ -11,50 +17,59 @@
         port_priority: 20
         timer: fast
 
-- name: Merge provided configuration with device configuration (base config)
-  register: baseconfig
-  become: true
-  arista.eos.eos_lacp_interfaces:
-    config: "{{ config1 }}"
-    state: merged
+- block:
+    - name: Merge provided configuration with device configuration (base config)
+      register: baseconfig
+      become: true
+      arista.eos.eos_lacp_interfaces:
+        config: "{{ config1 }}"
+        state: merged
 
-- become: true
-  arista.eos.eos_facts:
-    gather_network_resources: lacp_interfaces
+    - become: true
+      arista.eos.eos_facts:
+        gather_network_resources: lacp_interfaces
 
-- ansible.builtin.assert:
-    that:
-      - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(baseconfig.after)
-        == []
+    - ansible.builtin.assert:
+        that:
+          - ansible_facts.network_resources.lacp_interfaces|symmetric_difference(baseconfig.after)
+            == []
 
-- name: Merge provided configuration with device configuration
-  register: result
-  become: true
-  arista.eos.eos_lacp_interfaces:
-    config: "{{ config2 }}"
-    state: merged
+    - name: Merge provided configuration with device configuration
+      register: result
+      become: true
+      arista.eos.eos_lacp_interfaces:
+        config: "{{ config2 }}"
+        state: merged
 
-- ansible.builtin.set_fact:
-    expected_config:
-      - name: Ethernet1
-        port_priority: 30
-        timer: fast
+    - ansible.builtin.set_fact:
+        expected_config:
+          - name: Ethernet1
+            port_priority: 30
+            timer: fast
 
-      - name: Ethernet2
-        port_priority: 20
-        timer: fast
+          - name: Ethernet2
+            port_priority: 20
+            timer: fast
 
-- ansible.builtin.assert:
-    that:
-      - expected_config|symmetric_difference(result.after) == []
+    - ansible.builtin.assert:
+        that:
+          - expected_config|symmetric_difference(result.after) == []
 
-- name: Revert back to base config using facts round trip
-  become: true
-  register: revert
-  arista.eos.eos_lacp_interfaces:
-    config: "{{ ansible_facts['network_resources']['lacp_interfaces'] }}"
-    state: overridden
+    - name: Revert back to base config using facts round trip
+      become: true
+      register: revert
+      arista.eos.eos_lacp_interfaces:
+        config: "{{ ansible_facts['network_resources']['lacp_interfaces'] }}"
+        state: overridden
 
-- name: Assert that config was reverted
-  ansible.builtin.assert:
-    that: "{{ baseconfig.after | symmetric_difference(revert.after) == [] }}"
+    - name: Assert that config was reverted
+      ansible.builtin.assert:
+        that: "{{ baseconfig.after | symmetric_difference(revert.after) == [] }}"
+
+  always:
+    - ansible.builtin.include_tasks: _remove_config.yaml
+
+- ansible.builtin.debug:
+    msg:
+      END eos_lacp_interfaces round trip tests on connection={{ ansible_connection
+      }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

  - Fixed an testing issue where lacp interfaces configuration was not properly cleaned up after operations that changed the configuration, 
    resulting in config spill over. This update ensures that the configuration is correctly reset,
    preventing any unintended spill over.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
