### PR TITLE
Fix IPv6 static routes facts

### DIFF
--- a/changelogs/fragments/fix_statis_routes_ds_issue.yaml
+++ b/changelogs/fragments/fix_statis_routes_ds_issue.yaml
@@ -1,3 +1,5 @@
 ---
 bugfixes:
-  - make sure ipv6 static routes definitions are correctly filtered in facts gathering.
+  - Ensure IPv6 static route definitions are correctly filtered during facts gathering.
+  - Update the filter to accurately retrieve relevant static route configurations.
+  - Update integration tests for parse operations to ensure that ordering or address family (AF) does not affect assertions.

--- a/changelogs/fragments/fix_statis_routes_ds_issue.yaml
+++ b/changelogs/fragments/fix_statis_routes_ds_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - make sure ipv6 static routes definitions are correctly filtered in facts gathering.

--- a/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
@@ -54,11 +54,13 @@ class Static_routesFacts(object):
         :rtype: dictionary
         :returns: facts
         """
+        import q
         if not data:
             data = self.get_device_data(connection)
+            q(data)
 
         # split the config into instances of the resource
-        resource_delim = "ip.* route"
+        resource_delim = "ip.* route|ipv6.* route"
         find_pattern = r"(?:^|\n)%s.*?(?=(?:^|\n)%s|$)" % (
             resource_delim,
             resource_delim,
@@ -66,6 +68,7 @@ class Static_routesFacts(object):
         resources = [p.strip() for p in re.findall(find_pattern, data)]
         resources_without_vrf = []
         resource_vrf = {}
+        q(resources)
         for resource in resources:
             if resource and "vrf" not in resource:
                 resources_without_vrf.append(resource)

--- a/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
@@ -56,6 +56,8 @@ class Static_routesFacts(object):
         """
         if not data:
             data = self.get_device_data(connection)
+
+        # split the config into instances of the resource
         resource_delim = "ip.* route"
         find_pattern = r"(?:^|\n)%s.*?(?=(?:^|\n)%s|$)" % (
             resource_delim,
@@ -64,7 +66,6 @@ class Static_routesFacts(object):
         resources = [p.strip() for p in re.findall(find_pattern, data)]
         resources_without_vrf = []
         resource_vrf = {}
-        
         for resource in resources:
             if resource and "vrf" not in resource:
                 resources_without_vrf.append(resource)

--- a/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
@@ -54,21 +54,15 @@ class Static_routesFacts(object):
         :rtype: dictionary
         :returns: facts
         """
-        import q
         if not data:
             data = self.get_device_data(connection)
-            q(data)
 
-        # split the config into instances of the resource
-        resource_delim = "ip.* route|ipv6.* route"
-        find_pattern = r"(?:^|\n)%s.*?(?=(?:^|\n)%s|$)" % (
-            resource_delim,
-            resource_delim,
-        )
-        resources = [p.strip() for p in re.findall(find_pattern, data)]
+        resource_delim = r"(?:ip route|ipv6 route)"
+        find_pattern = r"(?:^|\n)(%s [^\n]*)(?=(?:^|\n)(?:%s|router ospf|$))" % (resource_delim, resource_delim)
+        resources = [p.strip() for p in re.findall(find_pattern, data, re.DOTALL)]
         resources_without_vrf = []
         resource_vrf = {}
-        q(resources)
+        
         for resource in resources:
             if resource and "vrf" not in resource:
                 resources_without_vrf.append(resource)

--- a/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/eos/facts/static_routes/static_routes.py
@@ -44,7 +44,7 @@ class Static_routesFacts(object):
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def get_device_data(self, connection):
-        return connection.get("show running-config | grep route")
+        return connection.get("show running-config | include ^ip route|^ipv6 route")
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for static_routes
@@ -56,10 +56,12 @@ class Static_routesFacts(object):
         """
         if not data:
             data = self.get_device_data(connection)
-
-        resource_delim = r"(?:ip route|ipv6 route)"
-        find_pattern = r"(?:^|\n)(%s [^\n]*)(?=(?:^|\n)(?:%s|router ospf|$))" % (resource_delim, resource_delim)
-        resources = [p.strip() for p in re.findall(find_pattern, data, re.DOTALL)]
+        resource_delim = "ip.* route"
+        find_pattern = r"(?:^|\n)%s.*?(?=(?:^|\n)%s|$)" % (
+            resource_delim,
+            resource_delim,
+        )
+        resources = [p.strip() for p in re.findall(find_pattern, data)]
         resources_without_vrf = []
         resource_vrf = {}
         

--- a/tests/integration/targets/eos_static_routes/tests/common/_parsed.cfg
+++ b/tests/integration/targets/eos_static_routes/tests/common/_parsed.cfg
@@ -5,3 +5,7 @@ ip route 23.1.0.0/16 Nexthop-Group testgrp tag 42
 ip route vrf testvrf 120.1.1.0/24 Ethernet1 23
 ip route vrf vrftest1 77.77.1.0/24 33.1.1.1
 ipv6 route 1000:10::/64 Ethernet1 67 tag 98
+router ospf 1
+   router-id 170.21.0.4
+router ospf 2 vrf vrf01
+router ospf 3 vrf vrf02

--- a/tests/integration/targets/eos_static_routes/tests/common/parsed.yaml
+++ b/tests/integration/targets/eos_static_routes/tests/common/parsed.yaml
@@ -14,6 +14,41 @@
       - default
     gather_network_resources:
       - static_routes
+- name: Set expect response to be asserted
+  ansible.builtin.set_fact:
+    expected_parsed_output:
+      - address_families:
+          - afi: ipv4
+            routes:
+              - dest: 10.1.1.0/24
+                next_hops:
+                  - interface: Management1
+                  - admin_distance: 200
+                    forward_router_address: 20.1.1.3
+                    interface: Ethernet1
+                    track: bfd
+              - dest: 10.50.0.0/16
+                next_hops:
+                  - interface: Management1
+              - dest: 23.1.0.0/16
+                next_hops:
+                  - nexthop_grp: testgrp
+                    tag: 42
+      - address_families:
+          - afi: ipv4
+            routes:
+              - dest: 120.1.1.0/24
+                next_hops:
+                  - admin_distance: 23
+                    interface: Ethernet1
+        vrf: testvrf
+      - address_families:
+          - afi: ipv4
+            routes:
+              - dest: 77.77.1.0/24
+                next_hops:
+                  - interface: 33.1.1.1
+        vrf: vrftest1
 
 - name: Provide the running configuration for parsing (config to be parsed)
   become: true
@@ -24,8 +59,8 @@
 
 - ansible.builtin.assert:
     that:
-      - "{{ ansible_facts['network_resources']['static_routes'] | symmetric_difference(result['parsed'])\
-        \ |length == 0 }}"
+      - "{{ expected_parsed_output | symmetric_difference(result['parsed']) |length ==\
+        \ 0 }}"
 
 - name: Gather the existing running configuration (IDEMPOTENT)
   become: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 - Ensure IPv6 static route definitions are correctly filtered during facts gathering.
  - Update the filter to accurately retrieve relevant static route configurations.
  - Update integration tests for parse operations to ensure that ordering or address family (AF) does not affect assertions.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_static_routes