### PR TITLE
Fix interface module setting idempotency

### DIFF
--- a/plugins/module_utils/network/eos/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/eos/facts/interfaces/interfaces.py
@@ -96,12 +96,8 @@ class InterfacesFacts(object):
         shutdown = utils.parse_conf_cmd_arg(conf, "shutdown", False)
         config["enabled"] = shutdown if shutdown is False else True
         config["mtu"] = utils.parse_conf_arg(conf, "mtu")
-        config["mode"] = utils.parse_conf_cmd_arg(
-            conf,
-            "switchport",
-            "layer2",
-            "layer3",
-        )
+        routed_port = utils.parse_conf_cmd_arg(conf, "no switchport", True)
+        config["mode"] = 'layer3' if routed_port else 'layer2'
 
         state = utils.parse_conf_arg(conf, "speed")
         if state:


### PR DESCRIPTION
##### SUMMARY

The interface module isn't idempotent as the `switchport` config stanza isn't present for L2 interfaces without running `show running-config` with the `all` option.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`arista.eos.eos_interfaces`

##### ADDITIONAL INFORMATION
 n/a
