### PR TITLE
Fix of configuration options for redistribution inside address-family 

### DIFF
--- a/docs/arista.eos.eos_bgp_address_family_module.rst
+++ b/docs/arista.eos.eos_bgp_address_family_module.rst
@@ -776,7 +776,11 @@ Parameters
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>isis</li>
                                     <li>ospfv3</li>
-                                    <li>dhcp</li>
+                                    <li>ospf</li>
+                                    <li>attached-host</li>
+                                    <li>connected</li>
+                                    <li>rip</li>
+                                    <li>static</li>
                         </ul>
                 </td>
                 <td>

--- a/plugins/module_utils/network/eos/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_address_family/bgp_address_family.py
@@ -85,13 +85,12 @@ class Bgp_afArgs(object):  # pylint: disable=R0903
                                 "protocol": {
                                     "type": "str",
                                     "choices": [
-                                        "isis"
-                                        "ospfv3",
+                                        "isis" "ospfv3",
                                         "ospf",
                                         "attached-host",
                                         "connected",
                                         "rip",
-                                        "static"
+                                        "static",
                                     ],
                                 },
                                 "isis_level": {

--- a/plugins/module_utils/network/eos/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_address_family/bgp_address_family.py
@@ -84,7 +84,15 @@ class Bgp_afArgs(object):  # pylint: disable=R0903
                                 "route_map": {"type": "str"},
                                 "protocol": {
                                     "type": "str",
-                                    "choices": ["isis", "ospfv3", "dhcp"],
+                                    "choices": [
+                                        "isis"
+                                        "ospfv3",
+                                        "ospf",
+                                        "attached-host",
+                                        "connected",
+                                        "rip",
+                                        "static"
+                                    ],
                                 },
                                 "isis_level": {
                                     "type": "str",

--- a/plugins/module_utils/network/eos/argspec/bgp_address_family/bgp_address_family.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_address_family/bgp_address_family.py
@@ -85,7 +85,8 @@ class Bgp_afArgs(object):  # pylint: disable=R0903
                                 "protocol": {
                                     "type": "str",
                                     "choices": [
-                                        "isis" "ospfv3",
+                                        "isis",
+                                        "ospfv3",
                                         "ospf",
                                         "attached-host",
                                         "connected",

--- a/plugins/modules/eos_bgp_address_family.py
+++ b/plugins/modules/eos_bgp_address_family.py
@@ -178,7 +178,7 @@ options:
                 protocol:
                   description: Routes to be redistributed.
                   type: str
-                  choices: ['isis', 'ospfv3', 'dhcp']
+                  choices: ['isis', 'ospfv3', 'ospf', 'attached-host', 'connected', 'rip', 'static']
                 route_map:
                   description: Route map reference.
                   type: str


### PR DESCRIPTION
##### SUMMARY

Fix of configurations options for redistribution inside Arista **eos_bgp_address_family** module 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME


-  arista.eos.eos_bgp_address_family

##### ADDITIONAL INFORMATION

##### Playbook example

```
- name: Read and parse BGP configuration for Arista EOS
  hosts: all
  gather_facts: no

  tasks:

    - name: Parse BGP address-family part of configuration
      arista.eos.eos_bgp_address_family:
        running_config: "{{ lookup('file', 'eos_parsed.cfg') }}"
        state: parsed

    - name: Save output to a file
      copy:
        content: "{{ output.parsed | to_json(indent=2) }}"
        dest: "./BGP_address_family_eos_config_parsed.cfg"
```

##### configuration to parse

```
(venv) ➜  ansible_testing cat eos_parsed.cfg  
router bgp 100
   !
   address-family ipv4
      neighbor 33.33.33.33 activate
      network 7.0.0.0/8
      redistribute connected route-map EXPORT-LOCAL-TO-BGP
```

##### Running the playbook
```
(venv) ➜  ansible_testing ansible-playbook play01_eos.yaml -i inventoryeos.ini  
PLAY [Read and parse BGP configuration for Arista EOS] ******************************************************************************************************************************

TASK [Parse BGP address-family part of configuration] *******************************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "value of protocol must be one of: isis, ospfv3, dhcp, got: connected found in config -> address_family -> redistribute"}

```

##### This part does not work 

```
router bgp 100
   address-family ipv4
       redistribute connected route-map EXPORT-LOCAL-TO-BGP
```

##### Confirmation of configurations options for redistribution inside address family

```
ceos1(config)#router bgp 100
ceos1(config-router-bgp)#   address-family ipv4
ceos1(config-router-bgp-af)#redistribute ?
  attached-host  ARP generated host routes
  bgp            Border Gateway Protocol
  connected      Connected interface routes
  dynamic        Dynamic policy routes
  isis           IS-IS routes
  ospf           OSPF protocol
  ospfv3         Open Shortest Path First (OSPFv3)
  rip            RIP routes
  static         Static routes
```


<br> 
<br>

##### In Global module, you can configure the same options for redistribution, but there are the right options. As you can see below:

- https://github.com/ansible-collections/arista.eos/blob/main/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py#L75
