### PR TITLE
Update route_maps.py to correctly handle ipv6 next-hop

### DIFF
--- a/plugins/module_utils/network/eos/rm_templates/route_maps.py
+++ b/plugins/module_utils/network/eos/rm_templates/route_maps.py
@@ -94,7 +94,7 @@ def _tmplt_route_map_ip(config_data):
         command = "set ip next-hop "
         k = "ip"
     elif config_data.get("ipv6"):
-        command = "set ip next-hop "
+        command = "set ipv6 next-hop "
         k = "ipv6"
     if config_data[k].get("address"):
         command += config_data[k]["address"]


### PR DESCRIPTION
fix ipv6 nexthop

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
correctly handle ipv6 next-hop

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route_maps, set ipv6 next-hop

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
