### PR TITLE
Bump minimum ansible version to 2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more information about communication, see the [Ansible communication guide](
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.15.0**.
+This collection has been tested against following Ansible versions: **>=2.16.0**.
 
 For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
 fully qualified collection name (for example, `cisco.ios.ios`).

--- a/changelogs/fragments/bump216.yaml
+++ b/changelogs/fragments/bump216.yaml
@@ -1,0 +1,6 @@
+---
+release_summary: >
+  With this release, the minimum required version of `ansible-core` for this collection is `2.16.0`.
+  The last version known to be compatible with `ansible-core` versions below `2.16` is v10.1.1.
+major_changes:
+  - Bumping `requires_ansible` to `>=2.16.0`, since previous ansible-core versions are EoL now.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"
 plugin_routing:
   modules:
     acl_interfaces:

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ">=3.9"
+  python_requires: ">=3.10"


### PR DESCRIPTION
##### SUMMARY
Bump minimum ansible version to 2.16
