### PR TITLE
in and out route maps implementation

### DIFF
--- a/changelogs/fragments/eos_bgp_global_route_maps_in_out.yaml
+++ b/changelogs/fragments/eos_bgp_global_route_maps_in_out.yaml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - |
+    eos_bgp_global - Support specifying both incoming and outgoing route-maps per BGP neighbor.
+    Added ``route_maps`` (list of dicts with ``name`` and ``direction``) so users can set
+    e.g. ``route-map MAP_IN in`` and ``route-map MAP_OUT out`` for the same neighbor.
+    The single ``route_map`` option is deprecated in favor of ``route_maps``.
+    Fixes https://github.com/ansible-collections/arista.eos/issues/538.

--- a/docs/arista.eos.eos_bgp_global_module.rst
+++ b/docs/arista.eos.eos_bgp_global_module.rst
@@ -2744,6 +2744,8 @@ Parameters
                 </td>
                 <td>
                         <div>Route map reference.</div>
+                        <div>Deprecated, use <em>route_maps</em> to specify both in and out route-maps per neighbor.</div>
+                        <div>This attribute will be removed after 2027-02-17.</div>
                 </td>
             </tr>
                                 <tr>
@@ -2784,6 +2786,67 @@ Parameters
                 </td>
                 <td>
                         <div>Route map name.</div>
+                </td>
+            </tr>
+
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="5">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>route_maps</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>List of route-maps to apply to the neighbor (in and/or out).</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>direction</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>in</li>
+                                    <li>out</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Direction of the route-map (inbound or outbound).</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the route-map.</div>
                 </td>
             </tr>
 
@@ -6488,6 +6551,8 @@ Parameters
                 </td>
                 <td>
                         <div>Route map reference.</div>
+                        <div>Deprecated, use <em>route_maps</em> to specify both in and out route-maps per neighbor.</div>
+                        <div>This attribute will be removed after 2027-02-17.</div>
                 </td>
             </tr>
                                 <tr>
@@ -6530,6 +6595,70 @@ Parameters
                 </td>
                 <td>
                         <div>Route map name.</div>
+                </td>
+            </tr>
+
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>route_maps</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>List of route-maps to apply to the neighbor (in and/or out).</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>direction</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>in</li>
+                                    <li>out</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Direction of the route-map (inbound or outbound).</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the route-map.</div>
                 </td>
             </tr>
 

--- a/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
@@ -30,6 +30,30 @@ __metaclass__ = type
 The arg spec for the eos_bgp_global module
 """
 
+# Shared neighbor option specs (used in config.neighbor and config.vrfs[].neighbor)
+_PREFIX_LIST_OPTION = {
+    "type": "dict",
+    "options": {
+        "direction": {"type": "str", "choices": ["in", "out"]},
+        "name": {"type": "str"},
+    },
+}
+_ROUTE_MAP_OPTION = {
+    "type": "dict",
+    "options": {
+        "direction": {"type": "str", "choices": ["in", "out"]},
+        "name": {"type": "str"},
+    },
+}
+_ROUTE_MAPS_OPTION = {
+    "type": "list",
+    "elements": "dict",
+    "options": {
+        "direction": {"type": "str", "choices": ["in", "out"], "required": True},
+        "name": {"type": "str", "required": True},
+    },
+}
+
 
 class Bgp_globalArgs(object):  # pylint: disable=R0903
     """The arg spec for the eos_bgp_global module"""
@@ -317,16 +341,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                         "peer_group": {"type": "str"},
                         "out_delay": {"type": "int"},
                         "import_localpref": {"type": "int"},
-                        "prefix_list": {
-                            "type": "dict",
-                            "options": {
-                                "direction": {
-                                    "type": "str",
-                                    "choices": ["in", "out"],
-                                },
-                                "name": {"type": "str"},
-                            },
-                        },
+                        "prefix_list": _PREFIX_LIST_OPTION,
                         "dont_capability_negotiate": {"type": "bool"},
                         "update_source": {"type": "str"},
                         "export_localpref": {"type": "int"},
@@ -422,28 +437,8 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                 "keepalive": {"type": "int"},
                             },
                         },
-                        "route_map": {
-                            "type": "dict",
-                            "options": {
-                                "direction": {
-                                    "type": "str",
-                                    "choices": ["in", "out"],
-                                },
-                                "name": {"type": "str"},
-                            },
-                        },
-                        "route_maps": {
-                            "type": "list",
-                            "elements": "dict",
-                            "options": {
-                                "direction": {
-                                    "type": "str",
-                                    "choices": ["in", "out"],
-                                    "required": True,
-                                },
-                                "name": {"type": "str", "required": True},
-                            },
-                        },
+                        "route_map": _ROUTE_MAP_OPTION,
+                        "route_maps": _ROUTE_MAPS_OPTION,
                         "remote_as": {"type": "str"},
                     },
                 },
@@ -789,16 +784,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                 "peer_group": {"type": "str"},
                                 "out_delay": {"type": "int"},
                                 "import_localpref": {"type": "int"},
-                                "prefix_list": {
-                                    "type": "dict",
-                                    "options": {
-                                        "direction": {
-                                            "type": "str",
-                                            "choices": ["in", "out"],
-                                        },
-                                        "name": {"type": "str"},
-                                    },
-                                },
+                                "prefix_list": _PREFIX_LIST_OPTION,
                                 "dont_capability_negotiate": {"type": "bool"},
                                 "update_source": {"type": "str"},
                                 "export_localpref": {"type": "int"},
@@ -901,28 +887,8 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                         "keepalive": {"type": "int"},
                                     },
                                 },
-                                "route_map": {
-                                    "type": "dict",
-                                    "options": {
-                                        "direction": {
-                                            "type": "str",
-                                            "choices": ["in", "out"],
-                                        },
-                                        "name": {"type": "str"},
-                                    },
-                                },
-                                "route_maps": {
-                                    "type": "list",
-                                    "elements": "dict",
-                                    "options": {
-                                        "direction": {
-                                            "type": "str",
-                                            "choices": ["in", "out"],
-                                            "required": True,
-                                        },
-                                        "name": {"type": "str", "required": True},
-                                    },
-                                },
+                                "route_map": _ROUTE_MAP_OPTION,
+                                "route_maps": _ROUTE_MAPS_OPTION,
                                 "remote_as": {"type": "str"},
                             },
                         },

--- a/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
@@ -431,6 +431,25 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                 },
                                 "name": {"type": "str"},
                             },
+                            "deprecated": True,
+                            "deprecation": {
+                                "version": "7.0.0",
+                                "date": "2025-01-01",
+                                "collection_name": "arista.eos",
+                                "reason": "Use route_maps to specify both in and out route-maps per neighbor.",
+                            },
+                        },
+                        "route_maps": {
+                            "type": "list",
+                            "elements": "dict",
+                            "options": {
+                                "direction": {
+                                    "type": "str",
+                                    "choices": ["in", "out"],
+                                    "required": True,
+                                },
+                                "name": {"type": "str", "required": True},
+                            },
                         },
                         "remote_as": {"type": "str"},
                     },
@@ -897,6 +916,25 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                             "choices": ["in", "out"],
                                         },
                                         "name": {"type": "str"},
+                                    },
+                                    "deprecated": True,
+                                    "deprecation": {
+                                        "version": "7.0.0",
+                                        "date": "2025-01-01",
+                                        "collection_name": "arista.eos",
+                                        "reason": "Use route_maps to specify both in and out route-maps per neighbor.",
+                                    },
+                                },
+                                "route_maps": {
+                                    "type": "list",
+                                    "elements": "dict",
+                                    "options": {
+                                        "direction": {
+                                            "type": "str",
+                                            "choices": ["in", "out"],
+                                            "required": True,
+                                        },
+                                        "name": {"type": "str", "required": True},
                                     },
                                 },
                                 "remote_as": {"type": "str"},

--- a/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/argspec/bgp_global/bgp_global.py
@@ -431,13 +431,6 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                 },
                                 "name": {"type": "str"},
                             },
-                            "deprecated": True,
-                            "deprecation": {
-                                "version": "7.0.0",
-                                "date": "2025-01-01",
-                                "collection_name": "arista.eos",
-                                "reason": "Use route_maps to specify both in and out route-maps per neighbor.",
-                            },
                         },
                         "route_maps": {
                             "type": "list",
@@ -916,13 +909,6 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                             "choices": ["in", "out"],
                                         },
                                         "name": {"type": "str"},
-                                    },
-                                    "deprecated": True,
-                                    "deprecation": {
-                                        "version": "7.0.0",
-                                        "date": "2025-01-01",
-                                        "collection_name": "arista.eos",
-                                        "reason": "Use route_maps to specify both in and out route-maps per neighbor.",
                                     },
                                 },
                                 "route_maps": {

--- a/plugins/module_utils/network/eos/config/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/config/bgp_global/bgp_global.py
@@ -317,6 +317,7 @@ class Bgp_global(ResourceModule):
             "neighbor.peer_group",
             "neighbor.prefix_list",
             "neighbor.route_map",
+            "neighbor.route_maps",
             "neighbor.route_reflector_client",
             "neighbor.route_to_peer",
             "neighbor.send_community",
@@ -331,11 +332,29 @@ class Bgp_global(ResourceModule):
         wneigh = want.pop("neighbor", {})
         hneigh = have.pop("neighbor", {})
         for name, entry in wneigh.items():
+            peer = entry.get("peer") or entry["neighbor_address"]
             for k, v in entry.items():
-                if entry.get("peer"):
-                    peer = entry["peer"]
-                else:
-                    peer = entry["neighbor_address"]
+                if k == "route_maps":
+                    # Compare route_maps list: add each want item, remove each have item not in want
+                    want_rms = v or []
+                    have_rms = (hneigh.get(name) or {}).pop("route_maps", None) or []
+                    want_set = {(rm["name"], rm["direction"]) for rm in want_rms}
+                    have_set = {(rm["name"], rm["direction"]) for rm in have_rms}
+                    for rm in want_rms:
+                        if (rm["name"], rm["direction"]) not in have_set:
+                            self.compare(
+                                parsers=parsers,
+                                want={"neighbor": {"neighbor_address": peer, "route_map": rm}},
+                                have={"neighbor": {"neighbor_address": peer}},
+                            )
+                    for rm in have_rms:
+                        if (rm["name"], rm["direction"]) not in want_set:
+                            self.compare(
+                                parsers=parsers,
+                                want={},
+                                have={"neighbor": {"neighbor_address": peer, "route_map": rm}},
+                            )
+                    continue
                 if hneigh.get(name):
                     h = {"neighbor_address": peer, k: hneigh[name].pop(k, {})}
                 else:
@@ -349,11 +368,15 @@ class Bgp_global(ResourceModule):
             if name not in wneigh.keys() and "peer_group" not in entry.keys():
                 self.commands.append("no neighbor " + name)
                 continue
+            peer = entry.get("neighbor_address", name)
             for k, v in entry.items():
+                if k == "route_maps":
+                    # Already handled in want loop (we pop from have when processing want)
+                    continue
                 self.compare(
                     parsers=parsers,
                     want={},
-                    have={"neighbor": {"neighbor_address": name, k: v}},
+                    have={"neighbor": {"neighbor_address": peer, k: v}},
                 )
 
     def _compare_lists(self, want, have):
@@ -381,6 +404,11 @@ class Bgp_global(ResourceModule):
                         peer = entry["peer"]
                     else:
                         peer = entry["neighbor_address"]
+                    # Normalize: convert deprecated route_map (single) to route_maps list
+                    if "route_map" in entry and entry.get("route_map"):
+                        if "route_maps" not in entry:
+                            entry["route_maps"] = [entry["route_map"]]
+                        entry.pop("route_map", None)
                     neigh_dict.update({peer: entry})
                 proc["neighbor"] = neigh_dict
 

--- a/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
+
 __metaclass__ = type
 
 """

--- a/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
@@ -39,39 +39,40 @@ class Bgp_globalFacts(object):
         """
         return connection.get("show running-config | section router\\sbgp ")
 
+    def _add_route_map_to_neighbor(self, objs, vrf_key, peer, name, direction):
+        """Add one route-map entry to the given neighbor in objs; no-op if vrf/neighbor missing."""
+        vrf_dict = objs.get("vrfs", {}).get(vrf_key)
+        if not vrf_dict or "neighbor" not in vrf_dict:
+            return
+        if peer not in vrf_dict["neighbor"]:
+            return
+        neighbor = vrf_dict["neighbor"][peer]
+        if "route_maps" not in neighbor:
+            neighbor["route_maps"] = []
+        neighbor["route_maps"].append({"name": name, "direction": direction})
+        neighbor.pop("route_map", None)
+
     def _collect_neighbor_route_maps(self, lines, objs):
         """Scan config lines for 'neighbor X route-map Y in|out' and set route_maps list per neighbor."""
         if not objs or "vrfs" not in objs:
             return
-        # Match: neighbor <peer> route-map <name> in|out
         neighbor_route_map_re = re.compile(
             r"^\s*neighbor\s+(\S+)\s+route-map\s+(\S+)\s+(in|out)\s*$",
         )
-        current_vrf_key = "vrf_"  # global
+        current_vrf_key = "vrf_"
         for line in lines:
             stripped = line.strip()
             if stripped.startswith("vrf "):
                 current_vrf_key = "vrf_" + stripped.split(None, 1)[1]
                 continue
             if stripped.startswith("exit") and current_vrf_key != "vrf_":
-                # Exiting a vrf block; next neighbor lines are global again
                 current_vrf_key = "vrf_"
                 continue
             match = neighbor_route_map_re.match(stripped)
             if not match:
                 continue
             peer, name, direction = match.groups()
-            vrf_dict = objs["vrfs"].get(current_vrf_key)
-            if not vrf_dict or "neighbor" not in vrf_dict:
-                continue
-            if peer not in vrf_dict["neighbor"]:
-                continue
-            neighbor = vrf_dict["neighbor"][peer]
-            if "route_maps" not in neighbor:
-                neighbor["route_maps"] = []
-            neighbor["route_maps"].append({"name": name, "direction": direction})
-            # Remove single route_map if present so route_maps is the source of truth
-            neighbor.pop("route_map", None)
+            self._add_route_map_to_neighbor(objs, current_vrf_key, peer, name, direction)
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_global network resource

--- a/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/eos/facts/bgp_global/bgp_global.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import re
 
 __metaclass__ = type
 
@@ -37,6 +38,40 @@ class Bgp_globalFacts(object):
         This method exists solely to allow the unit test framework to mock device connection calls.
         """
         return connection.get("show running-config | section router\\sbgp ")
+
+    def _collect_neighbor_route_maps(self, lines, objs):
+        """Scan config lines for 'neighbor X route-map Y in|out' and set route_maps list per neighbor."""
+        if not objs or "vrfs" not in objs:
+            return
+        # Match: neighbor <peer> route-map <name> in|out
+        neighbor_route_map_re = re.compile(
+            r"^\s*neighbor\s+(\S+)\s+route-map\s+(\S+)\s+(in|out)\s*$",
+        )
+        current_vrf_key = "vrf_"  # global
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("vrf "):
+                current_vrf_key = "vrf_" + stripped.split(None, 1)[1]
+                continue
+            if stripped.startswith("exit") and current_vrf_key != "vrf_":
+                # Exiting a vrf block; next neighbor lines are global again
+                current_vrf_key = "vrf_"
+                continue
+            match = neighbor_route_map_re.match(stripped)
+            if not match:
+                continue
+            peer, name, direction = match.groups()
+            vrf_dict = objs["vrfs"].get(current_vrf_key)
+            if not vrf_dict or "neighbor" not in vrf_dict:
+                continue
+            if peer not in vrf_dict["neighbor"]:
+                continue
+            neighbor = vrf_dict["neighbor"][peer]
+            if "route_maps" not in neighbor:
+                neighbor["route_maps"] = []
+            neighbor["route_maps"].append({"name": name, "direction": direction})
+            # Remove single route_map if present so route_maps is the source of truth
+            neighbor.pop("route_map", None)
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """Populate the facts for Bgp_global network resource
@@ -79,6 +114,10 @@ class Bgp_globalFacts(object):
             module=self._module,
         )
         objs = bgp_global_parser.parse()
+
+        # Collect all neighbor route-map lines (in and out) per peer per context
+        # so we can set route_maps as a list; EOS allows both "in" and "out" per neighbor.
+        self._collect_neighbor_route_maps(bgp_global_config, objs)
 
         if objs:
             global_vals = objs.get("vrfs", {}).pop("vrf_", {})

--- a/plugins/module_utils/network/eos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/eos/rm_templates/bgp_global.py
@@ -2351,8 +2351,35 @@ class Bgp_globalTemplate(NetworkTemplate):
         },
         {
             "name": "neighbor.route_maps",
+            "getval": re.compile(
+                r"""
+                \s*neighbor
+                \s+(?P<peer>\S+)
+                \s+route-map
+                \s+(?P<name>\S+)
+                \s+(?P<dir>in|out)
+                *$""",
+                re.VERBOSE,
+            ),
             "setval": _tmplt_bgp_neighbor,
             "compval": "neighbor.route_maps",
+            "result": {
+                "vrfs": {
+                    '{{ "vrf_" + vrf|d() }}': {
+                        "neighbor": {
+                            "{{ peer }}": {
+                                "neighbor_address": "{{ peer }}",
+                                "route_maps": [
+                                    {
+                                        "name": "{{ name }}",
+                                        "direction": "{{ dir }}",
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
         },
         {
             "name": "neighbor.route_reflector_client",

--- a/plugins/module_utils/network/eos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/eos/rm_templates/bgp_global.py
@@ -20,6 +20,9 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.r
     NetworkTemplate,
 )
 
+# Template placeholder used in parser result dicts (avoids string literal duplication for Sonar S1192)
+_ROUTE_MAP_NAME = "{{ name }}"
+
 
 def _tmplt_router_bgp_cmd(config_data):
     command = "router bgp {as_number}".format(**config_data)
@@ -2310,7 +2313,7 @@ class Bgp_globalTemplate(NetworkTemplate):
                             "{{ peer }}": {
                                 "neighbor_address": "{{ peer }}",
                                 "prefix_list": {
-                                    "name": "{{ name }}",
+                                    "name": _ROUTE_MAP_NAME,
                                     "direction": "{{ dir }}",
                                 },
                             },
@@ -2340,7 +2343,7 @@ class Bgp_globalTemplate(NetworkTemplate):
                             "{{ peer }}": {
                                 "neighbor_address": "{{ peer }}",
                                 "route_map": {
-                                    "name": "{{ name }}",
+                                    "name": _ROUTE_MAP_NAME,
                                     "direction": "{{ dir }}",
                                 },
                             },
@@ -2371,7 +2374,7 @@ class Bgp_globalTemplate(NetworkTemplate):
                                 "neighbor_address": "{{ peer }}",
                                 "route_maps": [
                                     {
-                                        "name": "{{ name }}",
+                                        "name": _ROUTE_MAP_NAME,
                                         "direction": "{{ dir }}",
                                     },
                                 ],

--- a/plugins/module_utils/network/eos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/eos/rm_templates/bgp_global.py
@@ -20,6 +20,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.r
     NetworkTemplate,
 )
 
+
 # Template placeholder used in parser result dicts (avoids string literal duplication for Sonar S1192)
 _ROUTE_MAP_NAME = "{{ name }}"
 

--- a/plugins/module_utils/network/eos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/eos/rm_templates/bgp_global.py
@@ -367,6 +367,14 @@ def _tmplt_bgp_neighbor(config_data):
         command += " prefix-list {name} {direction}".format(
             **config_data["neighbor"]["prefix_list"],
         )
+    elif config_data["neighbor"].get("route_maps"):
+        # Multiple route-maps (in and out) per neighbor; return list of commands.
+        # Base class prepends "no " when negate=True.
+        peer = config_data["neighbor"]["neighbor_address"]
+        return [
+            "neighbor %s route-map %s %s" % (peer, rm["name"], rm["direction"])
+            for rm in config_data["neighbor"]["route_maps"]
+        ]
     elif config_data["neighbor"].get("route_map"):
         command += " route-map {name} {direction}".format(**config_data["neighbor"]["route_map"])
     elif config_data["neighbor"].get("route_reflector_client"):
@@ -2340,6 +2348,11 @@ class Bgp_globalTemplate(NetworkTemplate):
                     },
                 },
             },
+        },
+        {
+            "name": "neighbor.route_maps",
+            "setval": _tmplt_bgp_neighbor,
+            "compval": "neighbor.route_maps",
         },
         {
             "name": "neighbor.route_reflector_client",

--- a/plugins/modules/eos_bgp_global.py
+++ b/plugins/modules/eos_bgp_global.py
@@ -529,7 +529,10 @@ options:
                   description: prefix list name.
                   type: str
             route_map:
-              description: Route map reference.
+              description:
+                - Route map reference.
+                - Deprecated, use I(route_maps) to specify both in and out route-maps per neighbor.
+                - This attribute will be removed after 2027-02-17.
               type: dict
               suboptions:
                 direction:
@@ -539,6 +542,20 @@ options:
                 name:
                   description: Route map name.
                   type: str
+            route_maps:
+              description: List of route-maps to apply to the neighbor (in and/or out).
+              type: list
+              elements: dict
+              suboptions:
+                name:
+                  description: Name of the route-map.
+                  type: str
+                  required: true
+                direction:
+                  description: Direction of the route-map (inbound or outbound).
+                  type: str
+                  required: true
+                  choices: ['in', 'out']
             route_reflector_client:
               description: Configure peer as a route reflector client.
               type: bool
@@ -1192,7 +1209,10 @@ options:
                       description: prefix list name.
                       type: str
                 route_map:
-                  description: Route map reference.
+                  description:
+                    - Route map reference.
+                    - Deprecated, use I(route_maps) to specify both in and out route-maps per neighbor.
+                    - This attribute will be removed after 2027-02-17.
                   type: dict
                   suboptions:
                     direction:
@@ -1202,6 +1222,20 @@ options:
                     name:
                       description: Route map name.
                       type: str
+                route_maps:
+                  description: List of route-maps to apply to the neighbor (in and/or out).
+                  type: list
+                  elements: dict
+                  suboptions:
+                    name:
+                      description: Name of the route-map.
+                      type: str
+                      required: true
+                    direction:
+                      description: Direction of the route-map (inbound or outbound).
+                      type: str
+                      required: true
+                      choices: ['in', 'out']
                 route_reflector_client:
                   description: Configure peer as a route reflector client.
                   type: bool

--- a/tests/unit/modules/network/eos/fixtures/eos_bgp_global_route_maps_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_bgp_global_route_maps_config.cfg
@@ -1,0 +1,5 @@
+router bgp 65000
+   router-id 192.0.2.1
+   neighbor 192.0.2.2 remote-as 65000
+   neighbor 192.0.2.2 route-map MAP_INCOMING in
+   neighbor 192.0.2.2 route-map MAP_OUTGOING out

--- a/tests/unit/modules/network/eos/fixtures/eos_bgp_global_route_maps_no_maps_config.cfg
+++ b/tests/unit/modules/network/eos/fixtures/eos_bgp_global_route_maps_no_maps_config.cfg
@@ -1,0 +1,3 @@
+router bgp 65000
+   router-id 192.0.2.1
+   neighbor 192.0.2.2 remote-as 65000

--- a/tests/unit/modules/network/eos/test_eos_bgp_global.py
+++ b/tests/unit/modules/network/eos/test_eos_bgp_global.py
@@ -875,3 +875,128 @@ class TestEosBgpglobalModule(TestEosModule):
             sorted(rendered_cmds),
             result["rendered"],
         )
+
+    def test_eos_bgp_global_merged_route_maps_in_out(self):
+        """Test merged with route_maps (both in and out) per neighbor - issue #538."""
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65000",
+                    router_id="192.0.2.1",
+                    neighbor=[
+                        dict(
+                            neighbor_address="192.0.2.2",
+                            remote_as="65000",
+                            route_maps=[
+                                dict(name="MAP_INCOMING", direction="in"),
+                                dict(name="MAP_OUTGOING", direction="out"),
+                            ],
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        # Use fixture that has neighbor but no route-maps yet, so merge adds them
+        result = self.execute_module(
+            changed=True,
+            filename="eos_bgp_global_route_maps_no_maps_config.cfg",
+        )
+        self.assertIn("neighbor 192.0.2.2 route-map MAP_INCOMING in", result["commands"])
+        self.assertIn("neighbor 192.0.2.2 route-map MAP_OUTGOING out", result["commands"])
+
+    def test_eos_bgp_global_merged_route_maps_idempotent(self):
+        """Test merged with route_maps is idempotent when config matches device."""
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65000",
+                    router_id="192.0.2.1",
+                    neighbor=[
+                        dict(
+                            neighbor_address="192.0.2.2",
+                            remote_as="65000",
+                            route_maps=[
+                                dict(name="MAP_INCOMING", direction="in"),
+                                dict(name="MAP_OUTGOING", direction="out"),
+                            ],
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        self.execute_module(
+            changed=False,
+            commands=[],
+            filename="eos_bgp_global_route_maps_config.cfg",
+        )
+
+    def test_eos_bgp_global_gathered_route_maps(self):
+        """Test gathered parses both in and out route-maps into route_maps list."""
+        set_module_args(dict(state="gathered"))
+        result = self.execute_module(
+            changed=False,
+            filename="eos_bgp_global_route_maps_config.cfg",
+        )
+        gathered = result["gathered"]
+        self.assertIn("neighbor", gathered)
+        neighbors = gathered["neighbor"]
+        self.assertEqual(len(neighbors), 1)
+        neighbor = neighbors[0]
+        self.assertIn("route_maps", neighbor)
+        route_maps = neighbor["route_maps"]
+        self.assertEqual(len(route_maps), 2)
+        names_dirs = {(rm["name"], rm["direction"]) for rm in route_maps}
+        self.assertIn(("MAP_INCOMING", "in"), names_dirs)
+        self.assertIn(("MAP_OUTGOING", "out"), names_dirs)
+
+    def test_eos_bgp_global_rendered_route_maps(self):
+        """Test rendered outputs both neighbor route-map in and out commands."""
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65000",
+                    router_id="192.0.2.1",
+                    neighbor=[
+                        dict(
+                            neighbor_address="192.0.2.2",
+                            remote_as="65000",
+                            route_maps=[
+                                dict(name="MAP_IN", direction="in"),
+                                dict(name="MAP_OUT", direction="out"),
+                            ],
+                        ),
+                    ],
+                ),
+                state="rendered",
+            ),
+        )
+        result = self.execute_module(changed=False)
+        rendered = result["rendered"]
+        self.assertIn("neighbor 192.0.2.2 route-map MAP_IN in", rendered)
+        self.assertIn("neighbor 192.0.2.2 route-map MAP_OUT out", rendered)
+
+    def test_eos_bgp_global_route_maps_deprecated_route_map_normalized(self):
+        """Test deprecated route_map (single) is normalized to route_maps and still works."""
+        set_module_args(
+            dict(
+                config=dict(
+                    as_number="65000",
+                    router_id="192.0.2.1",
+                    neighbor=[
+                        dict(
+                            neighbor_address="192.0.2.2",
+                            remote_as="65000",
+                            route_map=dict(name="MAP_SINGLE", direction="out"),
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        result = self.execute_module(
+            changed=True,
+            filename="eos_bgp_global_route_maps_config.cfg",
+        )
+        self.assertIn("neighbor 192.0.2.2 route-map MAP_SINGLE out", result["commands"])


### PR DESCRIPTION
## Description
 
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
-Adds route_maps (list with name/direction) to eos_bgp_global so each neighbor can have in and out route-maps; deprecates single route_map (removal 2027-02-17).  updates docs.Also fixes unit test failures (missing parser) and SonarCloud issues (complexity, duplication).
- Why is this change needed?
-Resolves #538 : users couldn’t set both in and out route-maps per neighbor. 
- How does this change address the issue?
route_maps is supported end-to-end; single route_map is normalized and deprecated with a clear removal date. Parser and facts refactors fix tests and reduce duplication so the quality gate passes.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue
<!-- Optional: Link to related issue(s) -->
- Fixes #
- Related to #

## Component Name
<!-- Mandatory: Specify the module, plugin, or component being changed -->
<!-- Examples: eos_config, eos_bgp_global, cliconf plugin, httpapi plugin, terminal plugin, etc. -->

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have removed all commented code (no commented code should be merged)
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment
- [ ] I have verified the changes work with the target EOS version(s)
- [ ] I have reviewed the acceptance criteria for related tickets

## Testing Instructions
<!-- Mandatory for all changes: Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required (e.g., EOS version, hardware platform, test topology) -->
- EOS Version:
- Hardware Platform (if applicable):
- Test Topology:

### Steps to Test
1.
2.
3.

### Expected Results
<!-- Describe what should happen after following the steps -->

### Test Results
<!-- Paste test output or describe test results -->
```
```

## Acceptance Criteria Verification
<!-- Mandatory: Verify that all acceptance criteria from the related ticket are met -->
- [ ] All acceptance criteria have been reviewed and verified
- [ ] Acceptance criteria checklist:
  - [ ]
  - [ ]
  - [ ]

## Additional Context
<!-- Optional but helpful information -->
<!-- Include additional information to help people understand the change here -->
<!-- A step-by-step reproduction of the problem is helpful if there is no related issue -->

### Command Output / Logs
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
<!-- Paste below -->
```

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- Module documentation, examples, platform guides -->
- [ ] Requires changelog fragment
  <!-- Create changelog fragment if this is a user-facing change -->
- [ ] Requires integration test updates
- [ ] Requires unit test updates
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
<!-- Include device output, error messages, or test results -->

### Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->
<!-- Remove section if not applicable -->
