### PR TITLE
Bugfix/accept multiline input via eapi

### DIFF
--- a/changelogs/fragments/fix-multiline-eapi-code-unit.yaml
+++ b/changelogs/fragments/fix-multiline-eapi-code-unit.yaml
@@ -1,0 +1,6 @@
+bugfixes:
+  - eos_config - extend multiline eAPI block detection to include ``code`` and
+    ``code unit`` (Routing Control Functions / RCF) in addition to ``banner``;
+    also bypass ``NetworkConfig`` in config-replace mode which was dropping
+    closing brace lines from RCF function bodies, causing EOS compilation failures
+    (https://github.com/ansible-collections/arista.eos/issues/632).

--- a/docs/arista.eos.eos_config_module.rst
+++ b/docs/arista.eos.eos_config_module.rst
@@ -298,7 +298,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Instructs the module on the way to perform the configuration on the device.  If the replace argument is set to <em>line</em> then the modified lines are pushed to the device in configuration mode.  If the replace argument is set to <em>block</em> then the entire command block is pushed to the device in configuration mode if any line is not correct.</div>
+                        <div>Instructs the module on the way to perform the configuration on the device.  If the replace argument is set to <em>line</em> then the modified lines are pushed to the device in configuration mode.  If the replace argument is set to <em>block</em> then the entire command block is pushed to the device in configuration mode if any line is not correct.  If the replace argument is set to <em>config</em> then the entire candidate configuration replaces the running configuration using a configuration session with <code>rollback clean-config</code>. This mode must be used when the candidate configuration contains multiline block commands such as <code>banner</code> or <code>code</code>/<code>code unit</code> (Routing Control Functions / RCF), as these require the eAPI <code>cmd</code>/<code>input</code> dict format and cannot be processed by the line-diff engine.</div>
                 </td>
             </tr>
             <tr>
@@ -365,6 +365,7 @@ Notes
    - Tested against Arista EOS 4.24.6F
    - Abbreviated commands are NOT idempotent, see `Network FAQ <../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands>`_.
    - To ensure idempotency and correct diff the configuration lines in the relevant module options should be similar to how they appear if present in the running configuration on device including the indentation.
+   - Multiline block commands such as ``banner`` and ``code unit`` (Routing Control Functions / RCF) require *replace=config* when using the eAPI transport. In this mode the module bypasses the standard line-diff engine, which cannot preserve brace-delimited syntax, and instead sends the full candidate configuration to the device using a configuration session with ``rollback clean-config``. The block content is automatically packaged into the eAPI ``cmd``/``input`` dict form required by the device.
 
 
 

--- a/plugins/module_utils/network/eos/eos.py
+++ b/plugins/module_utils/network/eos/eos.py
@@ -340,7 +340,8 @@ class HttpApi:
             # Bypass NetworkConfig entirely for full config replace and return candidate lines
             # with only basic filtering.
             config_lines = [
-                line for line in candidate.split("\n")
+                line
+                for line in candidate.split("\n")
                 if line.strip() and not line.strip().startswith("!")
             ]
             diff["config_diff"] = "\n".join(config_lines)
@@ -425,7 +426,9 @@ class HttpApi:
 
             # banner is always a multiline eAPI block; code is multiline only
             # within control-functions.
-            if stripped.startswith("banner") or (in_control_functions and stripped.startswith("code")):
+            if stripped.startswith("banner") or (
+                in_control_functions and stripped.startswith("code")
+            ):
                 multiline_cmd = stripped
                 multiline_input = []
                 continue

--- a/plugins/module_utils/network/eos/eos.py
+++ b/plugins/module_utils/network/eos/eos.py
@@ -50,7 +50,6 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 _DEVICE_CONNECTION = None
 
 
-
 def get_connection(module):
     global _DEVICE_CONNECTION
     if not _DEVICE_CONNECTION:

--- a/plugins/module_utils/network/eos/eos.py
+++ b/plugins/module_utils/network/eos/eos.py
@@ -50,6 +50,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 _DEVICE_CONNECTION = None
 
 
+
 def get_connection(module):
     global _DEVICE_CONNECTION
     if not _DEVICE_CONNECTION:
@@ -334,11 +335,23 @@ class HttpApi:
     ):
         diff = {}
 
+        if diff_replace == "config":
+            # NetworkConfig strips lines consisting only of `}` or `;` which breaks
+            # brace-delimited block syntax used `code unit` (Routing Control Function / RCF) syntax.
+            # Bypass NetworkConfig entirely for full config replace and return candidate lines
+            # with only basic filtering.
+            config_lines = [
+                line for line in candidate.split("\n")
+                if line.strip() and not line.strip().startswith("!")
+            ]
+            diff["config_diff"] = "\n".join(config_lines)
+            return diff
+
         # prepare candidate configuration
         candidate_obj = NetworkConfig(indent=3)
         candidate_obj.load(candidate)
 
-        if running and diff_match != "none" and diff_replace != "config":
+        if running and diff_match != "none":
             # running configuration
             running_obj = NetworkConfig(
                 indent=3,
@@ -376,30 +389,49 @@ class HttpApi:
         """
         session = session_name()
         result = {"session": session}
-        banner_cmd = None
-        banner_input = []
-
         commands = ["configure session %s" % session]
         if replace:
             commands.append("rollback clean-config")
 
+        multiline_cmd = None
+        multiline_input = []
+        in_control_functions = False
+        after_eof = False
+
         for command in config:
-            if command.startswith("banner"):
-                banner_cmd = command
-                banner_input = []
-            elif banner_cmd:
-                if command == "EOF":
-                    command = {
-                        "cmd": banner_cmd,
-                        "input": "\n".join(banner_input),
-                    }
-                    banner_cmd = None
-                    commands.append(command)
+            stripped = command.strip()
+
+            # Accumulate lines into the open multiline block until EOF closes it.
+            if multiline_cmd is not None:
+                if stripped == "EOF":
+                    commands.append({"cmd": multiline_cmd, "input": "\n".join(multiline_input)})
+                    multiline_cmd = None
+                    multiline_input = []
+                    after_eof = True
                 else:
-                    banner_input.append(command)
-                    continue
-            else:
-                commands.append(command)
+                    multiline_input.append(command)
+                continue
+
+            # The line immediately after a code block EOF determines whether we
+            # are still inside control-functions (another code block follows) or
+            # have exited it (any other command).
+            if after_eof:
+                after_eof = False
+                in_control_functions = stripped.startswith("code")
+
+            # Track entry into the control-functions context so that subsequent
+            # code blocks are recognised as multiline commands.
+            if stripped == "control-functions":
+                in_control_functions = True
+
+            # banner is always a multiline eAPI block; code is multiline only
+            # within control-functions.
+            if stripped.startswith("banner") or (in_control_functions and stripped.startswith("code")):
+                multiline_cmd = stripped
+                multiline_input = []
+                continue
+
+            commands.append(command)
 
         try:
             response = self._connection.send_request(commands)

--- a/plugins/module_utils/network/eos/eos.py
+++ b/plugins/module_utils/network/eos/eos.py
@@ -33,6 +33,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 import json
 import os
+import re
 import time
 
 from ansible.module_utils.common.text.converters import to_text
@@ -48,6 +49,10 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 
 
 _DEVICE_CONNECTION = None
+
+# Only bare `code` or `code unit NAME` opens a multiline RCF block. Other
+# `code …` forms (delete/source/command-tag) are single-line commands
+_MULTILINE_CODE_RE = re.compile(r"^code(?:\s+unit\s+\S+)?$")
 
 
 def get_connection(module):
@@ -417,7 +422,7 @@ class HttpApi:
             # have exited it (any other command).
             if after_eof:
                 after_eof = False
-                in_control_functions = stripped.startswith("code")
+                in_control_functions = bool(_MULTILINE_CODE_RE.match(stripped))
 
             # Track entry into the control-functions context so that subsequent
             # code blocks are recognised as multiline commands.
@@ -425,9 +430,10 @@ class HttpApi:
                 in_control_functions = True
 
             # banner is always a multiline eAPI block; code is multiline only
-            # within control-functions.
+            # within control-functions, and only for the bare `code [unit NAME]`
+            # form that opens a new RCF body.
             if stripped.startswith("banner") or (
-                in_control_functions and stripped.startswith("code")
+                in_control_functions and _MULTILINE_CODE_RE.match(stripped)
             ):
                 multiline_cmd = stripped
                 multiline_input = []

--- a/plugins/modules/eos_config.py
+++ b/plugins/modules/eos_config.py
@@ -36,6 +36,12 @@ notes:
   L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 - To ensure idempotency and correct diff the configuration lines in the relevant module options should be similar to how they
   appear if present in the running configuration on device including the indentation.
+- Multiline block commands such as C(banner) and C(code unit) (Routing Control Functions / RCF)
+  require I(replace=config) when using the eAPI transport. In this mode the module bypasses
+  the standard line-diff engine, which cannot preserve brace-delimited syntax, and instead
+  sends the full candidate configuration to the device using a configuration session with
+  C(rollback clean-config). The block content is automatically packaged into the eAPI
+  C(cmd)/C(input) dict form required by the device.
 options:
   lines:
     description:
@@ -114,7 +120,12 @@ options:
       the replace argument is set to I(line) then the modified lines are pushed to
       the device in configuration mode.  If the replace argument is set to I(block)
       then the entire command block is pushed to the device in configuration mode
-      if any line is not correct.
+      if any line is not correct.  If the replace argument is set to I(config) then
+      the entire candidate configuration replaces the running configuration using a
+      configuration session with C(rollback clean-config). This mode must be used when
+      the candidate configuration contains multiline block commands such as C(banner)
+      or C(code)/C(code unit) (Routing Control Functions / RCF), as these require the
+      eAPI C(cmd)/C(input) dict format and cannot be processed by the line-diff engine.
     type: str
     default: line
     choices:

--- a/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
+++ b/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
@@ -1,0 +1,194 @@
+---
+# Integration tests for multiline eAPI block handling (banner + code unit / RCF).
+#
+# Rationale: edit_config() in eos.py assembles {"cmd": ..., "input": ...} dicts
+# for commands that require multiline input over eAPI.  These tests exercise that
+# path end-to-end on a real device so we catch any breakage that unit tests
+# (which mock the connection) cannot.
+
+- ansible.builtin.debug:
+    msg: "START eapi/multiline_eapi.yaml on connection={{ ansible_connection }}"
+
+# ---------------------------------------------------------------------------
+# Teardown helper — run first to guarantee a clean slate
+# ---------------------------------------------------------------------------
+
+- name: teardown - remove login banner
+  become: true
+  arista.eos.eos_config:
+    lines: no banner login
+    match: none
+
+# ---------------------------------------------------------------------------
+# Banner block — regression guard for existing multiline eAPI behaviour
+# ---------------------------------------------------------------------------
+
+- name: Set login banner with multiline text via eos_config
+  become: true
+  register: result
+  arista.eos.eos_config:
+    lines:
+      - "banner login"
+      - "This is the first line."
+      - "This is the second line."
+      - "EOF"
+    match: none
+
+- ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - "'banner login' in result.updates"
+      - "'This is the first line.' in result.updates"
+      - "'This is the second line.' in result.updates"
+
+- name: Verify banner content was applied to the device
+  register: banner_output
+  arista.eos.eos_command:
+    commands:
+      - show banner login
+
+- ansible.builtin.assert:
+    that:
+      - "'This is the first line.' in banner_output.stdout[0]"
+      - "'This is the second line.' in banner_output.stdout[0]"
+    fail_msg: >-
+      Banner text not found on device after eAPI apply.
+      Device output: {{ banner_output.stdout[0] }}
+
+- name: Set same login banner again (idempotency check)
+  become: true
+  register: result
+  arista.eos.eos_config:
+    lines:
+      - "banner login"
+      - "This is the first line."
+      - "This is the second line."
+      - "EOF"
+
+- ansible.builtin.assert:
+    that:
+      - result.changed == false
+    fail_msg: >-
+      Expected changed=false on second identical banner application
+      but got changed={{ result.changed }}.  The multiline eAPI block
+      may not have been assembled correctly, causing a spurious diff.
+
+- name: teardown - remove login banner
+  become: true
+  arista.eos.eos_config:
+    lines: no banner login
+    match: none
+
+# ---------------------------------------------------------------------------
+# Code unit / RCF block — validates brace preservation over eAPI
+#
+# Prior to this fix, NetworkConfig stripped lines consisting only of `}` so
+# the closing brace of a function body was silently dropped when sent via
+# eAPI, producing invalid RCF syntax on the device.
+#
+# code unit blocks require replace=config because that is the only path
+# that bypasses NetworkConfig (which strips `}`) before the lines reach
+# edit_config for multiline eAPI block assembly.
+# ---------------------------------------------------------------------------
+
+- name: rcf teardown - remove code unit if present from a prior run
+  become: true
+  ignore_errors: true
+  arista.eos.eos_config:
+    lines:
+      - no code unit ANSIBLE_TEST_RCF
+    parents:
+      - router general
+      - control-functions
+    match: none
+
+- name: rcf - snapshot entire running config
+  register: snapshot
+  arista.eos.eos_command:
+    commands:
+      - show running-config
+
+- name: rcf - create temp file on controller
+  delegate_to: localhost
+  ansible.builtin.tempfile:
+    suffix: .cfg
+  register: rcf_tmpfile
+
+- name: rcf - write snapshot + RCF block to temp file
+  delegate_to: localhost
+  ansible.builtin.copy:
+    content: "{{ snapshot.stdout[0] | regex_replace('\nend\\s*$', '') }}\n{{ rcf_block }}"
+    dest: "{{ rcf_tmpfile.path }}"
+  vars:
+    rcf_block: |
+      router general
+         control-functions
+            code unit ANSIBLE_TEST_RCF
+               function testFunc() {
+                   return true;
+               }
+            EOF
+
+- name: rcf - push snapshot + RCF block via replace=config
+  become: true
+  register: result
+  arista.eos.eos_config:
+    src: "{{ rcf_tmpfile.path }}"
+    replace: config
+
+- ansible.builtin.assert:
+    that:
+      - result.changed == true
+    fail_msg: >-
+      Expected changed=true after applying RCF code unit via replace=config,
+      but got changed={{ result.changed }}.
+
+- name: rcf - verify code unit content on device, including closing brace
+  register: rcf_output
+  arista.eos.eos_command:
+    commands:
+      - show running-config | section router general
+
+- ansible.builtin.assert:
+    that:
+      - "'ANSIBLE_TEST_RCF' in rcf_output.stdout[0]"
+      - "'function testFunc()' in rcf_output.stdout[0]"
+      - "'return true;' in rcf_output.stdout[0]"
+      - "'}' in rcf_output.stdout[0]"
+    fail_msg: >-
+      RCF code unit content not found on device after eAPI apply.
+      Closing brace may have been dropped.
+      Device output: {{ rcf_output.stdout[0] }}
+
+- name: rcf - apply same config again (idempotency check)
+  become: true
+  register: result
+  arista.eos.eos_config:
+    src: "{{ rcf_tmpfile.path }}"
+    replace: config
+
+- ansible.builtin.assert:
+    that:
+      - result.changed == false
+    fail_msg: >-
+      Expected changed=false on second identical RCF apply
+      but got changed={{ result.changed }}.
+
+- name: rcf teardown - remove code unit
+  become: true
+  arista.eos.eos_config:
+    lines:
+      - no code unit ANSIBLE_TEST_RCF
+    parents:
+      - router general
+      - control-functions
+    match: none
+
+- name: rcf teardown - remove temp config file from controller
+  delegate_to: localhost
+  ansible.builtin.file:
+    path: "{{ rcf_tmpfile.path }}"
+    state: absent
+
+- ansible.builtin.debug:
+    msg: "END eapi/multiline_eapi.yaml"

--- a/tests/unit/modules/network/eos/test_eos_module_utils.py
+++ b/tests/unit/modules/network/eos/test_eos_module_utils.py
@@ -169,7 +169,7 @@ class TestHttpApiEditConfig(unittest.TestCase):
         self.assertEqual(dict_cmds[0]["cmd"], "code unit RCF")
         self.assertEqual(
             dict_cmds[0]["input"],
-            "         function foo() {\n" "             return true;\n" "         }",
+            "         function foo() {\n             return true;\n         }",
         )
 
     def test_multiple_code_unit_blocks(self):

--- a/tests/unit/modules/network/eos/test_eos_module_utils.py
+++ b/tests/unit/modules/network/eos/test_eos_module_utils.py
@@ -39,7 +39,7 @@ def _make_api():
 
 class TestHttpApiGetDiff(unittest.TestCase):
     def _get_diff(self, candidate, diff_replace="config", running=""):
-        api, _ = _make_api()
+        api, _conn = _make_api()
         return api.get_diff(
             candidate=candidate,
             running=running,
@@ -97,7 +97,7 @@ class TestHttpApiGetDiff(unittest.TestCase):
         """Non-config replace mode still computes a NetworkConfig diff."""
         running = "hostname localhost\n"
         candidate = "hostname switch01\n"
-        api, _ = _make_api()
+        api, _conn = _make_api()
         result = api.get_diff(
             candidate=candidate,
             running=running,
@@ -215,7 +215,7 @@ class TestHttpApiEditConfig(unittest.TestCase):
             "some other command",
         ]
         commands = self._sent_commands(config)
-        dict_cmds = self._dict_commands(commands) 
+        dict_cmds = self._dict_commands(commands)
         self.assertEqual(len(dict_cmds), 0)
         self.assertIn("code command", commands)
 

--- a/tests/unit/modules/network/eos/test_eos_module_utils.py
+++ b/tests/unit/modules/network/eos/test_eos_module_utils.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import unittest
+
 from unittest.mock import MagicMock, patch
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
@@ -140,7 +141,7 @@ class TestHttpApiEditConfig(unittest.TestCase):
             "banner login",
             "line one",
             "line two",
-            "EOF"
+            "EOF",
         ]
         commands = self._sent_commands(config)
         dict_cmds = self._dict_commands(commands)
@@ -168,9 +169,7 @@ class TestHttpApiEditConfig(unittest.TestCase):
         self.assertEqual(dict_cmds[0]["cmd"], "code unit RCF")
         self.assertEqual(
             dict_cmds[0]["input"],
-            "         function foo() {\n"
-            "             return true;\n"
-            "         }",
+            "         function foo() {\n" "             return true;\n" "         }",
         )
 
     def test_multiple_code_unit_blocks(self):

--- a/tests/unit/modules/network/eos/test_eos_module_utils.py
+++ b/tests/unit/modules/network/eos/test_eos_module_utils.py
@@ -1,0 +1,263 @@
+#
+# (c) 2026, Sonic.net, LLC
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
+    HttpApi,
+)
+
+
+def _make_api():
+    """Return an HttpApi instance with a mocked connection."""
+    module = MagicMock()
+    api = HttpApi(module)
+    mock_conn = MagicMock()
+    # edit_config calls send_request twice:
+    #   1. push the session config commands (return value unused)
+    #   2. show session-config diffs / commit / abort (response[1] is the diff)
+    mock_conn.send_request.side_effect = [
+        ["{}"],
+        ["", "", ""],
+    ]
+    api._connection_obj = mock_conn
+    return api, mock_conn
+
+
+# ---------------------------------------------------------------------------
+# HttpApi.get_diff  —  diff_replace="config" path
+# ---------------------------------------------------------------------------
+
+
+class TestHttpApiGetDiff(unittest.TestCase):
+    def _get_diff(self, candidate, diff_replace="config", running=""):
+        api, _ = _make_api()
+        return api.get_diff(
+            candidate=candidate,
+            running=running,
+            diff_replace=diff_replace,
+        )
+
+    # --- diff_replace="config" bypasses NetworkConfig ---
+
+    def test_config_replace_returns_candidate_lines(self):
+        """Regular config lines are returned verbatim."""
+        result = self._get_diff("hostname switch\nip routing\n")
+        self.assertIn("hostname switch", result["config_diff"])
+        self.assertIn("ip routing", result["config_diff"])
+
+    def test_config_replace_preserves_closing_braces(self):
+        """} lines are NOT dropped"""
+        candidate = (
+            "router general\n"
+            "   control-functions\n"
+            "      code unit RCF\n"
+            "         function foo() {\n"
+            "             return true;\n"
+            "         }\n"
+            "      EOF\n"
+        )
+        result = self._get_diff(candidate)
+        self.assertIn("         }", result["config_diff"])
+
+    def test_config_replace_preserves_semicolons(self):
+        """Lines ending with ; are not dropped."""
+        candidate = (
+            "      code unit RCF\n"
+            "         function foo() {\n"
+            "             return true;\n"
+            "         }\n"
+            "      EOF\n"
+        )
+        result = self._get_diff(candidate)
+        self.assertIn("             return true;", result["config_diff"])
+
+    def test_config_replace_filters_blank_lines(self):
+        result = self._get_diff("hostname switch\n\n\nip routing\n")
+        lines = result["config_diff"].split("\n")
+        self.assertNotIn("", lines)
+
+    def test_config_replace_filters_indented_bang_lines(self):
+        """! separators that appear with leading whitespace are also filtered."""
+        result = self._get_diff("router general\n   !\n   hardware next-hop fast-failover\n")
+        lines = result["config_diff"].split("\n")
+        self.assertFalse(any(line.strip().startswith("!") for line in lines))
+
+    # --- diff_replace="line" still uses NetworkConfig ---
+
+    def test_line_replace_uses_networkconfig_diff(self):
+        """Non-config replace mode still computes a NetworkConfig diff."""
+        running = "hostname localhost\n"
+        candidate = "hostname switch01\n"
+        api, _ = _make_api()
+        result = api.get_diff(
+            candidate=candidate,
+            running=running,
+            diff_replace="line",
+        )
+        self.assertIn("hostname switch01", result["config_diff"])
+        self.assertNotIn("hostname localhost", result["config_diff"])
+
+
+# ---------------------------------------------------------------------------
+# HttpApi.edit_config  —  multiline block assembly
+# ---------------------------------------------------------------------------
+
+
+class TestHttpApiEditConfig(unittest.TestCase):
+    def setUp(self):
+        self.mock_session = patch(
+            "ansible_collections.arista.eos.plugins.module_utils.network.eos.eos.session_name",
+            return_value="ansible_test",
+        )
+        self.mock_session.start()
+
+    def tearDown(self):
+        self.mock_session.stop()
+
+    def _sent_commands(self, config, replace=False):
+        """Run edit_config and return the commands list from the first send_request call."""
+        api, mock_conn = _make_api()
+        api.edit_config(config, replace=replace)
+        return mock_conn.send_request.call_args_list[0][0][0]
+
+    def _dict_commands(self, commands):
+        """Return only the dict entries from a commands list (i.e. multiline eAPI blocks)."""
+        return [c for c in commands if isinstance(c, dict)]
+
+    # --- banner block (regression — existing behaviour must be unchanged) ---
+
+    def test_banner_assembled_as_dict(self):
+        config = [
+            "banner login",
+            "line one",
+            "line two",
+            "EOF"
+        ]
+        commands = self._sent_commands(config)
+        dict_cmds = self._dict_commands(commands)
+        self.assertEqual(len(dict_cmds), 1)
+        self.assertEqual(dict_cmds[0]["cmd"], "banner login")
+        self.assertEqual(dict_cmds[0]["input"], "line one\nline two")
+
+    # --- code unit block ---
+
+    def test_code_unit_assembled_as_dict_with_correct_input(self):
+        """code unit block produces one dict with the correct cmd and verbatim input,
+        including closing braces which NetworkConfig previously dropped."""
+        config = [
+            "router general",
+            "   control-functions",
+            "      code unit RCF",
+            "         function foo() {",
+            "             return true;",
+            "         }",
+            "      EOF",
+        ]
+        commands = self._sent_commands(config)
+        dict_cmds = self._dict_commands(commands)
+        self.assertEqual(len(dict_cmds), 1)
+        self.assertEqual(dict_cmds[0]["cmd"], "code unit RCF")
+        self.assertEqual(
+            dict_cmds[0]["input"],
+            "         function foo() {\n"
+            "             return true;\n"
+            "         }",
+        )
+
+    def test_multiple_code_unit_blocks(self):
+        config = [
+            "router general",
+            "   control-functions",
+            "      code unit BLOCK1",
+            "         function a() { return true; }",
+            "      EOF",
+            "      code unit BLOCK2",
+            "         function b() { return false; }",
+            "      EOF",
+        ]
+        commands = self._sent_commands(config)
+        dict_cmds = self._dict_commands(commands)
+        self.assertEqual(len(dict_cmds), 2)
+        self.assertEqual(dict_cmds[0]["cmd"], "code unit BLOCK1")
+        self.assertEqual(dict_cmds[0]["input"], "         function a() { return true; }")
+        self.assertEqual(dict_cmds[1]["cmd"], "code unit BLOCK2")
+        self.assertEqual(dict_cmds[1]["input"], "         function b() { return false; }")
+
+    def test_plain_code_inside_control_functions_assembled_as_dict(self):
+        """Plain 'code' (without 'unit') inside control-functions is also a multiline block."""
+        config = [
+            "router general",
+            "   control-functions",
+            "      code",
+            "         function foo() {",
+            "             return true;",
+            "         }",
+            "      EOF",
+        ]
+        commands = self._sent_commands(config)
+        dict_cmds = self._dict_commands(commands)
+        self.assertEqual(len(dict_cmds), 1)
+        self.assertEqual(dict_cmds[0]["cmd"], "code")
+
+    def test_code_outside_control_functions_not_treated_as_multiline(self):
+        """A line starting with 'code' outside control-functions is a plain command."""
+        config = [
+            "code command",
+            "some other command",
+        ]
+        commands = self._sent_commands(config)
+        dict_cmds = self._dict_commands(commands) 
+        self.assertEqual(len(dict_cmds), 0)
+        self.assertIn("code command", commands)
+
+    def test_context_exits_after_last_code_block(self):
+        """After the final EOF in control-functions, subsequent 'code' lines elsewhere
+        in the config are not treated as multiline blocks."""
+        config = [
+            "router general",
+            "   control-functions",
+            "      code unit RCF",
+            "         function f() { return true; }",
+            "      EOF",
+            "some top level command",
+        ]
+        commands = self._sent_commands(config)
+        dict_cmds = self._dict_commands(commands)
+        self.assertEqual(len(dict_cmds), 1)
+        self.assertEqual(dict_cmds[0]["cmd"], "code unit RCF")
+        self.assertIn("some top level command", commands)
+
+    # --- banner + code unit together ---
+
+    def test_mixed_banner_and_code_unit_blocks(self):
+        """A config containing both block types produces two dicts in the correct order."""
+        config = [
+            "banner login",
+            "Welcome to this device",
+            "EOF",
+            "router general",
+            "   control-functions",
+            "      code unit RCF",
+            "         function f() {",
+            "             return true;",
+            "         }",
+            "      EOF",
+        ]
+        commands = self._sent_commands(config)
+        dict_cmds = self._dict_commands(commands)
+        self.assertEqual(len(dict_cmds), 2)
+        self.assertEqual(dict_cmds[0]["cmd"], "banner login")
+        self.assertEqual(dict_cmds[1]["cmd"], "code unit RCF")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/modules/network/eos/test_eos_module_utils.py
+++ b/tests/unit/modules/network/eos/test_eos_module_utils.py
@@ -1,5 +1,5 @@
 #
-# (c) 2026, Sonic.net, LLC
+# (c) 2026, Ansible by Red Hat, inc
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
 

--- a/tests/unit/modules/network/eos/test_eos_module_utils.py
+++ b/tests/unit/modules/network/eos/test_eos_module_utils.py
@@ -218,6 +218,50 @@ class TestHttpApiEditConfig(unittest.TestCase):
         self.assertEqual(len(dict_cmds), 0)
         self.assertIn("code command", commands)
 
+    def test_non_multiline_code_forms_not_assembled(self):
+        """`code unit X (delete|replace|insert) block function …`,
+        `code unit X source pulled-from …`, and `code unit X command-tag …`
+        are single-line commands that reorganize or reference existing
+        functions and take no body — none should be assembled as a
+        multiline eAPI block."""
+        for line in [
+            "code unit RCF delete block function foo @LBL",
+            "code unit RCF replace block function foo @LBL",
+            "code unit RCF insert block function foo before @LBL",
+            "code unit RCF insert block function foo after @LBL",
+            "code unit RCF source pulled-from http://example.com/rcf.txt",
+            "code unit RCF command-tag MYTAG",
+        ]:
+            with self.subTest(line=line):
+                config = [
+                    "router general",
+                    "   control-functions",
+                    "      " + line,
+                    "      hardware next-hop fast-failover",
+                ]
+                commands = self._sent_commands(config)
+                dict_cmds = self._dict_commands(commands)
+                self.assertEqual(len(dict_cmds), 0)
+                self.assertIn("      " + line, commands)
+
+    def test_code_block_after_non_multiline_code_line(self):
+        """A non-multiline `code …` line (e.g. delete) must not flip the
+        control functions context off — a real `code unit X` block that
+        follows still gets assembled as multiline."""
+        config = [
+            "router general",
+            "   control-functions",
+            "      code unit RCF delete block function foo @LBL",
+            "      code unit RCF",
+            "         function bar() { return true; }",
+            "      EOF",
+        ]
+        commands = self._sent_commands(config)
+        dict_cmds = self._dict_commands(commands)
+        self.assertEqual(len(dict_cmds), 1)
+        self.assertEqual(dict_cmds[0]["cmd"], "code unit RCF")
+        self.assertIn("      code unit RCF delete block function foo @LBL", commands)
+
     def test_context_exits_after_last_code_block(self):
         """After the final EOF in control-functions, subsequent 'code' lines elsewhere
         in the config are not treated as multiline blocks."""


### PR DESCRIPTION
## Description
- **What is being changed?** `edit_config()` in the httpapi plugin is extended to
  recognise `code` and `code unit` (Routing Control Functions / RCF) blocks as
  multiline eAPI commands, assembling them as `{"cmd": ..., "input": ...}` dicts
  alongside the existing `banner` handling. `get_diff()` is updated to bypass
  `NetworkConfig` when `replace: config` is set, returning candidate lines directly
  instead.

- **Why is this change needed?** Two bugs prevented RCF configs from being applied
  via `eos_config`:
  1. `code`/`code unit` block bodies were sent as individual CLI tokens, causing EOS
     to reject them with `Invalid input (at token 0: 'function')`.
  2. `NetworkConfig` uses a brace-stripping regex (`r"([{};])"`) before its blank-line
     check, which silently dropped standalone `}` lines from RCF function bodies,
     causing EOS to report `missing '}'` and fail compilation.

- **How does this change address the issue?** The multiline block assembly loop now
  tracks when it is inside the `control-functions` context and treats `code`/`code unit`
  headers as block openers terminated by `EOF`, matching the existing `banner` pattern.
  For `replace: config`, `NetworkConfig` is bypassed entirely since no line-diff is
  needed — candidate lines are returned directly with only blank and `!` comment lines
  filtered.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Related Issue
- Resolves #632
- Resolves #526

## Component Name
`eos_config`, httpapi plugin (`plugins/module_utils/network/eos/eos.py`)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have removed all commented code (no commented code should be merged)
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target EOS version(s)
- [x] I have reviewed the acceptance criteria for related tickets

## Testing Instructions
### Prerequisites
- EOS Version: 4.28+ (any version supporting Routing Control Functions)
- Hardware Platform: any
- Test Topology: single EOS device reachable via eAPI

### Steps to Test
1. Create a new playbook and payload
```
- hosts: eos_device
  gather_facts: false
  tasks:
    - name: Push RCF and banner config
      arista.eos.eos_config:
        replace: config
        src: test_rcf_candidate.cfg
```
```
banner login
Authorized access only.
EOF
router general
   control-functions
      code unit ALLOW_ALL
         function ALLOW_ALL() {
            return true;
         }
      EOF
      code DENY_DEFAULT
         function DENY_DEFAULT() {
            if prefix is 0.0.0.0/0 {
               return false;
            }
            return true;
         }
      EOF
hostname changed.hostname
```
2. Run playbook against any version of EOS that supports RCF

### Expected Results
- EOS accepts the RCF config block and reports no compilation errors.
- Existing `banner` behavior is unchanged.

### Test Results
ansible-test sanity --python 3.12  →  no errors on changed files
pytest tests/unit/modules/network/eos/test_eos_module_utils.py -n 0  →  15 tests passed
Push to cEOS successful with banner and RCF configuration included

## Acceptance Criteria Verification
- [x] Acceptance criteria checklist:
  - [x] `code unit` blocks sent as multiline eAPI dicts, not individual tokens
  - [x] `replace: config` no longer drops `}` lines from RCF function bodies
  - [x] `banner` regression tests pass unchanged
  - [x] Changelog fragment included

## Required Actions
- [x] Requires changelog fragment — included at `changelogs/fragments/fix-multiline-eapi-code-unit.yaml`
- [x] Requires unit test updates — new file `tests/unit/modules/network/eos/test_eos_module_utils.py`