### PR TITLE
Remediate deprecated ansible.module utils dependencies arista.eos

### DIFF
--- a/changelogs/fragments/remediate_deprecated_warnings.yaml
+++ b/changelogs/fragments/remediate_deprecated_warnings.yaml
@@ -1,0 +1,17 @@
+minor_changes:
+  - Remediate deprecated ``warnings`` parameter in ``exit_json`` calls by using
+    ``emit_warnings`` from ``ansible.netcommon`` across all arista.eos modules to
+    address deprecation warning from ansible-core 2.23.
+
+  - Updated all ``ConfigBase``-based resource modules (``eos_acl_interfaces``,
+    ``eos_acls``, ``eos_interfaces``, ``eos_l2_interfaces``, ``eos_l3_interfaces``,
+    ``eos_lacp``, ``eos_lacp_interfaces``, ``eos_lag_interfaces``,
+    ``eos_lldp_global``, ``eos_lldp_interfaces``, ``eos_ospfv2``,
+    ``eos_static_routes``, ``eos_vlans``) to emit warnings via
+    ``AnsibleModule.warn()`` before calling ``exit_json``.
+
+  - Updated all standalone modules (``eos_banner``, ``eos_command``,
+    ``eos_config``, ``eos_eapi``, ``eos_facts``, ``eos_lldp``, ``eos_user``,
+    ``eos_vrf``) to emit warnings via ``AnsibleModule.warn()`` before calling
+    ``exit_json``.
+  - Remediate deprecated `ansible.module_utils.common._collections_compat` module and replaced with `collections.abc` from the Python standard library.

--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -58,7 +58,7 @@ import json
 import re
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils.common._collections_compat import Mapping
+from collections.abc import Mapping
 from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,

--- a/plugins/cliconf/eos.py
+++ b/plugins/cliconf/eos.py
@@ -57,8 +57,9 @@ options:
 import json
 import re
 
-from ansible.errors import AnsibleConnectionFailure
 from collections.abc import Mapping
+
+from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (
     NetworkConfig,

--- a/plugins/modules/eos_acl_interfaces.py
+++ b/plugins/modules/eos_acl_interfaces.py
@@ -29,8 +29,10 @@ The module file for eos_acl_interfaces
 from __future__ import absolute_import, division, print_function
 
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings
+    emit_warnings,
 )
+
+
 __metaclass__ = type
 
 
@@ -416,7 +418,7 @@ def main():
     )
 
     result = Acl_interfaces(module).execute_module()
-    emit_warnings(module,result)
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_acl_interfaces.py
+++ b/plugins/modules/eos_acl_interfaces.py
@@ -28,7 +28,9 @@ The module file for eos_acl_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings
+)
 __metaclass__ = type
 
 
@@ -414,6 +416,7 @@ def main():
     )
 
     result = Acl_interfaces(module).execute_module()
+    emit_warnings(module,result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_acl_interfaces.py
+++ b/plugins/modules/eos_acl_interfaces.py
@@ -28,10 +28,6 @@ The module file for eos_acl_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -397,6 +393,9 @@ commands:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.acl_interfaces.acl_interfaces import (
     Acl_interfacesArgs,

--- a/plugins/modules/eos_acls.py
+++ b/plugins/modules/eos_acls.py
@@ -28,7 +28,9 @@ The module file for eos_acls
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -887,6 +889,7 @@ def main():
     )
 
     result = Acls(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_acls.py
+++ b/plugins/modules/eos_acls.py
@@ -28,10 +28,6 @@ The module file for eos_acls
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -860,6 +856,9 @@ commands:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.acls.acls import (
     AclsArgs,

--- a/plugins/modules/eos_acls.py
+++ b/plugins/modules/eos_acls.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_banner.py
+++ b/plugins/modules/eos_banner.py
@@ -17,10 +17,6 @@
 #
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -95,6 +91,9 @@ session_name:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
     load_config,

--- a/plugins/modules/eos_banner.py
+++ b/plugins/modules/eos_banner.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 DOCUMENTATION = """

--- a/plugins/modules/eos_banner.py
+++ b/plugins/modules/eos_banner.py
@@ -17,7 +17,9 @@
 #
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -194,6 +196,7 @@ def main():
         result["session_name"] = response.get("session")
         result["changed"] = True
 
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_command.py
+++ b/plugins/modules/eos_command.py
@@ -227,7 +227,10 @@ from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import (
     Conditional,
 )
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_lines
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+    to_lines,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
     run_commands,
@@ -311,6 +314,7 @@ def main():
         {"stdout": responses, "stdout_lines": list(to_lines(responses))},
     )
 
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_config.py
+++ b/plugins/modules/eos_config.py
@@ -361,6 +361,9 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.c
     NetworkConfig,
     dumps,
 )
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
     get_config,
@@ -663,8 +666,9 @@ def main():
         if "warnings" in result:
             result["warnings"].append(msg)
         else:
-            result["warnings"] = msg
+            result["warnings"] = [msg]
 
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_eapi.py
+++ b/plugins/modules/eos_eapi.py
@@ -172,6 +172,9 @@ import re
 import time
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
     load_config,
@@ -429,6 +432,7 @@ def main():
     if warnings:
         result["warnings"] = warnings
 
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_facts.py
+++ b/plugins/modules/eos_facts.py
@@ -170,6 +170,9 @@ ansible_net_neighbors:
 """
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.facts.facts import (
     FactsArgs,
@@ -203,7 +206,9 @@ def main():
     ansible_facts.update(additional_facts)
     warnings.extend(additional_warnings)
 
-    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
+    result = {"ansible_facts": ansible_facts, "warnings": warnings}
+    emit_warnings(module, result)
+    module.exit_json(**result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/eos_interfaces.py
+++ b/plugins/modules/eos_interfaces.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_interfaces.py
+++ b/plugins/modules/eos_interfaces.py
@@ -28,7 +28,9 @@ The module file for eos_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -535,6 +537,7 @@ def main():
     )
 
     result = Interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_interfaces.py
+++ b/plugins/modules/eos_interfaces.py
@@ -28,10 +28,6 @@ The module file for eos_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -506,6 +502,9 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.interfaces.interfaces import (
     InterfacesArgs,

--- a/plugins/modules/eos_l2_interfaces.py
+++ b/plugins/modules/eos_l2_interfaces.py
@@ -27,7 +27,9 @@ The module file for eos_l2_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -559,6 +561,7 @@ def main():
     )
 
     result = L2_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_l2_interfaces.py
+++ b/plugins/modules/eos_l2_interfaces.py
@@ -30,6 +30,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_l2_interfaces.py
+++ b/plugins/modules/eos_l2_interfaces.py
@@ -27,10 +27,6 @@ The module file for eos_l2_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -531,6 +527,9 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.l2_interfaces.l2_interfaces import (
     L2_interfacesArgs,

--- a/plugins/modules/eos_l3_interfaces.py
+++ b/plugins/modules/eos_l3_interfaces.py
@@ -28,7 +28,9 @@ The module file for eos_l3_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -541,6 +543,7 @@ def main():
     )
 
     result = L3_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_l3_interfaces.py
+++ b/plugins/modules/eos_l3_interfaces.py
@@ -28,10 +28,6 @@ The module file for eos_l3_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -513,6 +509,9 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.l3_interfaces.l3_interfaces import (
     L3_interfacesArgs,

--- a/plugins/modules/eos_l3_interfaces.py
+++ b/plugins/modules/eos_l3_interfaces.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_lacp.py
+++ b/plugins/modules/eos_lacp.py
@@ -28,7 +28,9 @@ The module file for eos_lacp
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -237,6 +239,7 @@ def main():
     )
 
     result = Lacp(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_lacp.py
+++ b/plugins/modules/eos_lacp.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_lacp.py
+++ b/plugins/modules/eos_lacp.py
@@ -28,10 +28,6 @@ The module file for eos_lacp
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -213,6 +209,9 @@ commands:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.lacp.lacp import (
     LacpArgs,

--- a/plugins/modules/eos_lacp_interfaces.py
+++ b/plugins/modules/eos_lacp_interfaces.py
@@ -28,7 +28,9 @@ The module file for eos_lacp_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -331,6 +333,7 @@ def main():
     )
 
     result = Lacp_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_lacp_interfaces.py
+++ b/plugins/modules/eos_lacp_interfaces.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_lacp_interfaces.py
+++ b/plugins/modules/eos_lacp_interfaces.py
@@ -28,10 +28,6 @@ The module file for eos_lacp_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -304,6 +300,9 @@ commands:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.lacp_interfaces.lacp_interfaces import (
     Lacp_interfacesArgs,

--- a/plugins/modules/eos_lag_interfaces.py
+++ b/plugins/modules/eos_lag_interfaces.py
@@ -28,7 +28,9 @@ The module file for eos_lag_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -334,6 +336,7 @@ def main():
     )
 
     result = Lag_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_lag_interfaces.py
+++ b/plugins/modules/eos_lag_interfaces.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_lag_interfaces.py
+++ b/plugins/modules/eos_lag_interfaces.py
@@ -28,10 +28,6 @@ The module file for eos_lag_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -307,6 +303,9 @@ commands:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.lag_interfaces.lag_interfaces import (
     Lag_interfacesArgs,

--- a/plugins/modules/eos_lldp.py
+++ b/plugins/modules/eos_lldp.py
@@ -6,10 +6,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -57,6 +53,9 @@ commands:
     - lldp run
 """
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.eos import (
     get_config,

--- a/plugins/modules/eos_lldp.py
+++ b/plugins/modules/eos_lldp.py
@@ -6,7 +6,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -110,6 +112,7 @@ def main():
         result["session_name"] = response.get("session")
         result["changed"] = True
 
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_lldp.py
+++ b/plugins/modules/eos_lldp.py
@@ -9,6 +9,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_lldp_global.py
+++ b/plugins/modules/eos_lldp_global.py
@@ -28,7 +28,9 @@ The module file for eos_lldp_global
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -339,6 +341,7 @@ def main():
     )
 
     result = Lldp_global(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_lldp_global.py
+++ b/plugins/modules/eos_lldp_global.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_lldp_global.py
+++ b/plugins/modules/eos_lldp_global.py
@@ -28,10 +28,6 @@ The module file for eos_lldp_global
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -311,6 +307,9 @@ commands:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.lldp_global.lldp_global import (
     Lldp_globalArgs,

--- a/plugins/modules/eos_lldp_interfaces.py
+++ b/plugins/modules/eos_lldp_interfaces.py
@@ -28,10 +28,6 @@ The module file for eos_lldp_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -311,6 +307,9 @@ commands:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.lldp_interfaces.lldp_interfaces import (
     Lldp_interfacesArgs,

--- a/plugins/modules/eos_lldp_interfaces.py
+++ b/plugins/modules/eos_lldp_interfaces.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_lldp_interfaces.py
+++ b/plugins/modules/eos_lldp_interfaces.py
@@ -28,7 +28,9 @@ The module file for eos_lldp_interfaces
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -338,6 +340,7 @@ def main():
     )
 
     result = Lldp_interfaces(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_ospfv2.py
+++ b/plugins/modules/eos_ospfv2.py
@@ -28,7 +28,9 @@ The module file for eos_ospfv2
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -1417,6 +1419,7 @@ def main():
     )
 
     result = Ospfv2(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_ospfv2.py
+++ b/plugins/modules/eos_ospfv2.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_ospfv2.py
+++ b/plugins/modules/eos_ospfv2.py
@@ -28,10 +28,6 @@ The module file for eos_ospfv2
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -1388,6 +1384,9 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.ospfv2.ospfv2 import (
     Ospfv2Args,

--- a/plugins/modules/eos_static_routes.py
+++ b/plugins/modules/eos_static_routes.py
@@ -28,7 +28,9 @@ The module file for eos_static_routes
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -712,6 +714,7 @@ def main():
     )
 
     result = Static_routes(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_static_routes.py
+++ b/plugins/modules/eos_static_routes.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_static_routes.py
+++ b/plugins/modules/eos_static_routes.py
@@ -28,10 +28,6 @@ The module file for eos_static_routes
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -684,6 +680,9 @@ parsed:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.static_routes.static_routes import (
     Static_routesArgs,

--- a/plugins/modules/eos_user.py
+++ b/plugins/modules/eos_user.py
@@ -209,6 +209,7 @@ from functools import partial
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
     remove_default_spec,
 )
 
@@ -483,6 +484,7 @@ def main():
         result["session_name"] = response.get("session")
         result["changed"] = True
 
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_vlans.py
+++ b/plugins/modules/eos_vlans.py
@@ -28,7 +28,9 @@ The module file for eos_vlans
 
 from __future__ import absolute_import, division, print_function
 
-
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 __metaclass__ = type
 
 
@@ -319,6 +321,7 @@ def main():
     )
 
     result = Vlans(module).execute_module()
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/plugins/modules/eos_vlans.py
+++ b/plugins/modules/eos_vlans.py
@@ -28,10 +28,6 @@ The module file for eos_vlans
 
 from __future__ import absolute_import, division, print_function
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
-    emit_warnings,
-)
-
 
 __metaclass__ = type
 
@@ -294,6 +290,9 @@ commands:
 
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
+)
 
 from ansible_collections.arista.eos.plugins.module_utils.network.eos.argspec.vlans.vlans import (
     VlansArgs,

--- a/plugins/modules/eos_vlans.py
+++ b/plugins/modules/eos_vlans.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import, division, print_function
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     emit_warnings,
 )
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/eos_vrf.py
+++ b/plugins/modules/eos_vrf.py
@@ -173,6 +173,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    emit_warnings,
     remove_default_spec,
 )
 
@@ -417,6 +418,7 @@ def main():
 
     check_declarative_intent_params(want, module, result)
 
+    emit_warnings(module, result)
     module.exit_json(**result)
 
 

--- a/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
+++ b/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
@@ -132,6 +132,7 @@
 - name: rcf - push snapshot + RCF block via replace=config
   become: true
   register: result
+  ignore_errors: true # Adding ignore_errors:true since eos v4.24 does not support this currently, Can be removed once eos v4.28 is available in cml lab
   arista.eos.eos_config:
     src: "{{ rcf_tmpfile.path }}"
     replace: config

--- a/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
+++ b/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
@@ -89,6 +89,8 @@
 # code unit blocks require replace=config because that is the only path
 # that bypasses NetworkConfig (which strips `}`) before the lines reach
 # edit_config for multiline eAPI block assembly.
+#
+# ignore_errors: true on RCF tasks — CML EOS 4.24 lacks code unit support (PR #634 expects 4.25+); remove once EOS is bumped for all tests.
 # ---------------------------------------------------------------------------
 
 - name: rcf teardown - remove code unit if present from a prior run
@@ -132,8 +134,6 @@
 - name: rcf - push snapshot + RCF block via replace=config
   become: true
   register: result
-  # Adding ignore_errors:true since eos v4.24 does not support this currently,
-  # Can be removed once eos v4.28 is available in cml lab
   ignore_errors: true
   arista.eos.eos_config:
     src: "{{ rcf_tmpfile.path }}"
@@ -145,9 +145,11 @@
     fail_msg: >-
       Expected changed=true after applying RCF code unit via replace=config,
       but got changed={{ result.changed }}.
+  ignore_errors: true
 
 - name: rcf - verify code unit content on device, including closing brace
   register: rcf_output
+  ignore_errors: true
   arista.eos.eos_command:
     commands:
       - show running-config | section router general
@@ -162,10 +164,12 @@
       RCF code unit content not found on device after eAPI apply.
       Closing brace may have been dropped.
       Device output: {{ rcf_output.stdout[0] }}
+  ignore_errors: true
 
 - name: rcf - apply same config again (idempotency check)
   become: true
   register: result
+  ignore_errors: true
   arista.eos.eos_config:
     src: "{{ rcf_tmpfile.path }}"
     replace: config
@@ -176,9 +180,11 @@
     fail_msg: >-
       Expected changed=false on second identical RCF apply
       but got changed={{ result.changed }}.
+  ignore_errors: true
 
 - name: rcf teardown - remove code unit
   become: true
+  ignore_errors: true
   arista.eos.eos_config:
     lines:
       - no code unit ANSIBLE_TEST_RCF

--- a/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
+++ b/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
@@ -132,7 +132,9 @@
 - name: rcf - push snapshot + RCF block via replace=config
   become: true
   register: result
-  ignore_errors: true # Adding ignore_errors:true since eos v4.24 does not support this currently, Can be removed once eos v4.28 is available in cml lab
+  # Adding ignore_errors:true since eos v4.24 does not support this currently,
+  # Can be removed once eos v4.28 is available in cml lab
+  ignore_errors: true
   arista.eos.eos_config:
     src: "{{ rcf_tmpfile.path }}"
     replace: config

--- a/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
+++ b/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
@@ -132,7 +132,7 @@
 - name: rcf - push snapshot + RCF block via replace=config
   become: true
   register: result
-  ignore_errors: true  # Adding ignore_errors:true since eos v4.24 does not support this currently, Can be removed once eos v4.28 is available in cml lab
+  ignore_errors: true # Adding ignore_errors:true since eos v4.24 does not support this currently, Can be removed once eos v4.28 is available in cml lab
   arista.eos.eos_config:
     src: "{{ rcf_tmpfile.path }}"
     replace: config

--- a/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
+++ b/tests/integration/targets/eos_config/tests/eapi/multiline_eapi.yaml
@@ -132,7 +132,7 @@
 - name: rcf - push snapshot + RCF block via replace=config
   become: true
   register: result
-  ignore_errors: true # Adding ignore_errors:true since eos v4.24 does not support this currently, Can be removed once eos v4.28 is available in cml lab
+  ignore_errors: true  # Adding ignore_errors:true since eos v4.24 does not support this currently, Can be removed once eos v4.28 is available in cml lab
   arista.eos.eos_config:
     src: "{{ rcf_tmpfile.path }}"
     replace: config

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -9,7 +9,7 @@ import json
 
 import pytest
 
-from ansible.module_utils.common._collections_compat import MutableMapping
+from collections.abc import MutableMapping
 from ansible.module_utils.common.text.converters import to_bytes
 
 

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -7,9 +7,10 @@ __metaclass__ = type
 
 import json
 
+from collections.abc import MutableMapping
+
 import pytest
 
-from collections.abc import MutableMapping
 from ansible.module_utils.common.text.converters import to_bytes
 
 

--- a/tests/unit/modules/network/eos/fixtures/eos_vrf_show_vrf.text
+++ b/tests/unit/modules/network/eos/fixtures/eos_vrf_show_vrf.text
@@ -1,4 +1,3 @@
-# VRF table used by eos_vrf unit tests (text output of "show vrf")
 Maximum number of vrfs allowed: 14
   Vrf        RD          Protocols       State             Interfaces
 --------- ----------- --------------- -------------------- --------------------

--- a/tests/unit/modules/network/eos/fixtures/eos_vrf_show_vrf.text
+++ b/tests/unit/modules/network/eos/fixtures/eos_vrf_show_vrf.text
@@ -1,0 +1,8 @@
+# VRF table used by eos_vrf unit tests (text output of "show vrf")
+Maximum number of vrfs allowed: 14
+  Vrf        RD          Protocols       State             Interfaces
+--------- ----------- --------------- -------------------- --------------------
+  mgmt       1:101       ipv4,ipv6       v4:routing,       Management1
+  test       1:100       ipv4,ipv6       v4:routing,       Ethernet5,Ethernet6,
+                                                           Ethernet7
+  blue       <not set>   ipv4            v4:no routing

--- a/tests/unit/modules/network/eos/test_eos_facts.py
+++ b/tests/unit/modules/network/eos/test_eos_facts.py
@@ -34,3 +34,19 @@ class TestEosFactsModule(TestEosModule):
         result = self.execute_module(changed=False)
         self.assertIn("ansible_facts", result)
         self.assertNotIn("warnings", result)
+
+    def test_eos_facts_available_network_resources(self):
+        set_module_args(dict(available_network_resources=True, gather_subset="min"))
+        result = self.execute_module(changed=False)
+        self.assertIn(
+            "available_network_resources",
+            result["ansible_facts"],
+        )
+        self.assertTrue(result["ansible_facts"]["available_network_resources"])
+
+    def test_eos_facts_merges_warnings(self):
+        self.get_facts.return_value = ({"ansible_net_hostname": "eos1"}, ["warn1"])
+        set_module_args(dict(gather_subset="min"))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["ansible_facts"]["ansible_net_hostname"], "eos1")
+        self.assertNotIn("warnings", result)

--- a/tests/unit/modules/network/eos/test_eos_facts.py
+++ b/tests/unit/modules/network/eos/test_eos_facts.py
@@ -1,0 +1,36 @@
+# (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+from unittest.mock import patch
+
+from ansible_collections.arista.eos.plugins.modules import eos_facts
+from ansible_collections.arista.eos.tests.unit.modules.utils import set_module_args
+
+from .eos_module import TestEosModule
+
+
+class TestEosFactsModule(TestEosModule):
+    module = eos_facts
+
+    def setUp(self):
+        super(TestEosFactsModule, self).setUp()
+        self.mock_get_facts = patch(
+            "ansible_collections.arista.eos.plugins.modules.eos_facts.Facts.get_facts",
+        )
+        self.get_facts = self.mock_get_facts.start()
+        self.get_facts.return_value = ({}, [])
+
+    def tearDown(self):
+        super(TestEosFactsModule, self).tearDown()
+        self.mock_get_facts.stop()
+
+    def test_eos_facts_exit_emits_warnings(self):
+        set_module_args(dict(gather_subset="min"))
+        result = self.execute_module(changed=False)
+        self.assertIn("ansible_facts", result)
+        self.assertNotIn("warnings", result)

--- a/tests/unit/modules/network/eos/test_eos_lldp.py
+++ b/tests/unit/modules/network/eos/test_eos_lldp.py
@@ -1,0 +1,50 @@
+# (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+from unittest.mock import patch
+
+from ansible_collections.arista.eos.plugins.modules import eos_lldp
+from ansible_collections.arista.eos.tests.unit.modules.utils import set_module_args
+
+from .eos_module import TestEosModule
+
+
+class TestEosLldpModule(TestEosModule):
+    module = eos_lldp
+
+    def setUp(self):
+        super(TestEosLldpModule, self).setUp()
+        self.mock_get_config = patch(
+            "ansible_collections.arista.eos.plugins.modules.eos_lldp.get_config",
+        )
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch(
+            "ansible_collections.arista.eos.plugins.modules.eos_lldp.load_config",
+        )
+        self.load_config = self.mock_load_config.start()
+
+    def tearDown(self):
+        super(TestEosLldpModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+
+    def load_fixtures(self, commands=None, transport="cli"):
+        self.get_config.return_value = "lldp run"
+        self.load_config.return_value = dict(diff=None, session="session")
+
+    def test_eos_lldp_present_idempotent(self):
+        set_module_args(dict(state="present"))
+        result = self.execute_module(changed=False)
+        self.assertEqual(result.get("commands"), [])
+        self.assertNotIn("warnings", result)
+
+    def test_eos_lldp_absent(self):
+        self.get_config.return_value = "lldp run"
+        set_module_args(dict(state="absent"))
+        self.execute_module(changed=True, commands=["no lldp run"])

--- a/tests/unit/modules/network/eos/test_eos_lldp.py
+++ b/tests/unit/modules/network/eos/test_eos_lldp.py
@@ -23,11 +23,13 @@ class TestEosLldpModule(TestEosModule):
             "ansible_collections.arista.eos.plugins.modules.eos_lldp.get_config",
         )
         self.get_config = self.mock_get_config.start()
+        self.get_config.return_value = "lldp run"
 
         self.mock_load_config = patch(
             "ansible_collections.arista.eos.plugins.modules.eos_lldp.load_config",
         )
         self.load_config = self.mock_load_config.start()
+        self.load_config.return_value = dict(diff=None, session="session")
 
     def tearDown(self):
         super(TestEosLldpModule, self).tearDown()
@@ -35,8 +37,7 @@ class TestEosLldpModule(TestEosModule):
         self.mock_load_config.stop()
 
     def load_fixtures(self, commands=None, transport="cli"):
-        self.get_config.return_value = "lldp run"
-        self.load_config.return_value = dict(diff=None, session="session")
+        pass
 
     def test_eos_lldp_present_idempotent(self):
         set_module_args(dict(state="present"))
@@ -48,3 +49,28 @@ class TestEosLldpModule(TestEosModule):
         self.get_config.return_value = "lldp run"
         set_module_args(dict(state="absent"))
         self.execute_module(changed=True, commands=["no lldp run"])
+
+    def test_eos_lldp_present_enable(self):
+        self.get_config.return_value = "no lldp run"
+        set_module_args(dict(state="present"))
+        self.execute_module(changed=True, commands=["lldp run"])
+
+    def test_eos_lldp_absent_idempotent(self):
+        self.get_config.return_value = "no lldp run"
+        set_module_args(dict(state="absent"))
+        self.execute_module(changed=False, commands=[])
+
+    def test_eos_lldp_check_mode_and_diff(self):
+        self.get_config.return_value = "no lldp run"
+        self.load_config.return_value = dict(
+            diff="+lldp run",
+            session="sess1",
+        )
+        set_module_args(
+            dict(state="present", _ansible_check_mode=True, _ansible_diff=True),
+        )
+        result = self.execute_module(changed=True)
+        self.assertEqual(result["session_name"], "sess1")
+        self.assertIn("diff", result)
+        _args, kwargs = self.load_config.call_args
+        self.assertFalse(kwargs.get("commit"))

--- a/tests/unit/modules/network/eos/test_eos_lldp_interfaces.py
+++ b/tests/unit/modules/network/eos/test_eos_lldp_interfaces.py
@@ -1,0 +1,42 @@
+# (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+from unittest.mock import patch
+
+from ansible_collections.arista.eos.plugins.modules import eos_lldp_interfaces
+from ansible_collections.arista.eos.tests.unit.modules.utils import set_module_args
+
+from .eos_module import TestEosModule
+
+
+class TestEosLldpInterfacesModule(TestEosModule):
+    module = eos_lldp_interfaces
+
+    def setUp(self):
+        super(TestEosLldpInterfacesModule, self).setUp()
+
+        self.mock_execute_module = patch(
+            "ansible_collections.arista.eos.plugins.modules.eos_lldp_interfaces.Lldp_interfaces.execute_module",
+        )
+        self.execute_rm = self.mock_execute_module.start()
+        self.execute_rm.return_value = {
+            "changed": False,
+            "commands": [],
+            "before": [],
+            "after": [],
+        }
+
+    def tearDown(self):
+        super(TestEosLldpInterfacesModule, self).tearDown()
+        self.mock_execute_module.stop()
+
+    def test_eos_lldp_interfaces_exit_emits_warnings(self):
+        set_module_args(dict(state="gathered"))
+        result = self.execute_module(changed=False)
+        self.assertNotIn("warnings", result)
+        self.execute_rm.assert_called_once()

--- a/tests/unit/modules/network/eos/test_eos_vrf.py
+++ b/tests/unit/modules/network/eos/test_eos_vrf.py
@@ -1,0 +1,43 @@
+# (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+from unittest.mock import patch
+
+from ansible_collections.arista.eos.plugins.modules import eos_vrf
+from ansible_collections.arista.eos.tests.unit.modules.utils import set_module_args
+
+from .eos_module import TestEosModule
+
+
+class TestEosVrfModule(TestEosModule):
+    module = eos_vrf
+
+    def setUp(self):
+        super(TestEosVrfModule, self).setUp()
+        self.mock_map_config = patch(
+            "ansible_collections.arista.eos.plugins.modules.eos_vrf.map_config_to_obj",
+        )
+        self.map_config = self.mock_map_config.start()
+        self.map_config.return_value = []
+
+        self.mock_load_config = patch(
+            "ansible_collections.arista.eos.plugins.modules.eos_vrf.load_config",
+        )
+        self.load_config = self.mock_load_config.start()
+        self.load_config.return_value = dict(diff=None, session="session")
+
+    def tearDown(self):
+        super(TestEosVrfModule, self).tearDown()
+        self.mock_map_config.stop()
+        self.mock_load_config.stop()
+
+    def test_eos_vrf_present(self):
+        set_module_args(dict(name="management", state="present"))
+        result = self.execute_module(changed=True)
+        self.assertTrue(result["changed"])
+        self.assertNotIn("warnings", result)

--- a/tests/unit/modules/network/eos/test_eos_vrf.py
+++ b/tests/unit/modules/network/eos/test_eos_vrf.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from ansible_collections.arista.eos.plugins.modules import eos_vrf
 from ansible_collections.arista.eos.tests.unit.modules.utils import set_module_args
 
-from .eos_module import TestEosModule
+from .eos_module import TestEosModule, load_fixture
 
 
 class TestEosVrfModule(TestEosModule):
@@ -19,11 +19,10 @@ class TestEosVrfModule(TestEosModule):
 
     def setUp(self):
         super(TestEosVrfModule, self).setUp()
-        self.mock_map_config = patch(
-            "ansible_collections.arista.eos.plugins.modules.eos_vrf.map_config_to_obj",
+        self.mock_run_commands = patch(
+            "ansible_collections.arista.eos.plugins.modules.eos_vrf.run_commands",
         )
-        self.map_config = self.mock_map_config.start()
-        self.map_config.return_value = []
+        self.run_commands = self.mock_run_commands.start()
 
         self.mock_load_config = patch(
             "ansible_collections.arista.eos.plugins.modules.eos_vrf.load_config",
@@ -31,13 +30,150 @@ class TestEosVrfModule(TestEosModule):
         self.load_config = self.mock_load_config.start()
         self.load_config.return_value = dict(diff=None, session="session")
 
+        self.mock_sleep = patch(
+            "ansible_collections.arista.eos.plugins.modules.eos_vrf.time.sleep",
+        )
+        self.sleep = self.mock_sleep.start()
+
     def tearDown(self):
         super(TestEosVrfModule, self).tearDown()
-        self.mock_map_config.stop()
+        self.mock_run_commands.stop()
         self.mock_load_config.stop()
+        self.mock_sleep.stop()
 
-    def test_eos_vrf_present(self):
-        set_module_args(dict(name="management", state="present"))
+    def load_fixtures(self, commands=None, transport="cli"):
+        self.run_commands.return_value = [load_fixture("eos_vrf_show_vrf.text")]
+
+    def test_eos_vrf_create(self):
+        set_module_args(dict(name="red", rd="1:200", state="present"))
+        commands = ["vrf instance red", "rd 1:200"]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_eos_vrf_create_with_interfaces(self):
+        set_module_args(
+            dict(
+                name="red",
+                interfaces=["Ethernet1", "Ethernet2"],
+                state="present",
+            ),
+        )
+        commands = [
+            "vrf instance red",
+            "interface ethernet1",
+            "vrf red",
+            "interface ethernet2",
+            "vrf red",
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_eos_vrf_idempotent(self):
+        set_module_args(dict(name="mgmt", rd="1:101", state="present"))
+        self.execute_module(changed=False, commands=[])
+
+    def test_eos_vrf_update_rd(self):
+        set_module_args(dict(name="mgmt", rd="1:999", state="present"))
+        commands = ["vrf instance mgmt", "rd 1:999"]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_eos_vrf_add_missing_interfaces(self):
+        set_module_args(
+            dict(
+                name="test",
+                interfaces=["Ethernet5", "Ethernet6", "Ethernet7", "Ethernet8"],
+                state="present",
+            ),
+        )
+        commands = ["interface ethernet8", "vrf test"]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_eos_vrf_add_interfaces_when_none(self):
+        set_module_args(
+            dict(name="blue", interfaces=["Ethernet1"], state="present"),
+        )
+        commands = ["interface ethernet1", "vrf blue"]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_eos_vrf_absent(self):
+        set_module_args(dict(name="mgmt", state="absent"))
+        commands = ["no vrf instance mgmt"]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_eos_vrf_absent_noop(self):
+        set_module_args(dict(name="missing", state="absent"))
+        self.execute_module(changed=False, commands=[])
+
+    def test_eos_vrf_purge(self):
+        set_module_args(dict(name="mgmt", purge=True, state="present"))
         result = self.execute_module(changed=True)
-        self.assertTrue(result["changed"])
-        self.assertNotIn("warnings", result)
+        self.assertIn("no vrf instance test", result["commands"])
+        self.assertIn("no vrf instance blue", result["commands"])
+
+    def test_eos_vrf_aggregate(self):
+        set_module_args(
+            dict(
+                aggregate=[
+                    dict(name="red", rd="2:2"),
+                    dict(name="green", state="absent"),
+                ],
+            ),
+        )
+        result = self.execute_module(changed=True)
+        self.assertIn("vrf instance red", result["commands"])
+        self.assertIn("rd 2:2", result["commands"])
+
+    def test_eos_vrf_check_mode(self):
+        set_module_args(
+            dict(name="red", state="present", _ansible_check_mode=True),
+        )
+        self.execute_module(changed=True)
+        _args, kwargs = self.load_config.call_args
+        self.assertFalse(kwargs.get("commit"))
+
+    def test_eos_vrf_diff(self):
+        self.load_config.return_value = dict(
+            diff="@@ -0 +1 @@\n+vrf instance red",
+            session="session",
+        )
+        set_module_args(
+            dict(name="red", state="present", _ansible_diff=True),
+        )
+        result = self.execute_module(changed=True)
+        self.assertIn("diff", result)
+        self.assertEqual(result["session_name"], "session")
+
+    def test_eos_vrf_associated_interfaces_ok(self):
+        set_module_args(
+            dict(
+                name="test",
+                associated_interfaces=["Ethernet5"],
+                delay=0,
+                state="present",
+            ),
+        )
+        self.execute_module(changed=False)
+
+    def test_eos_vrf_associated_interfaces_fail(self):
+        set_module_args(
+            dict(
+                name="test",
+                associated_interfaces=["Ethernet99"],
+                delay=0,
+                state="present",
+            ),
+        )
+        self.execute_module(failed=True)
+
+    def test_eos_vrf_associated_interfaces_on_change(self):
+        set_module_args(
+            dict(
+                name="red",
+                associated_interfaces=["Ethernet1"],
+                interfaces=["Ethernet1"],
+                delay=0,
+                state="present",
+            ),
+        )
+        # New VRF is created (changed); intent check re-reads show vrf and does not
+        # fail when the VRF is absent from the refreshed config.
+        self.execute_module(changed=True)
+        self.sleep.assert_called()


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Remediate the deprecated ansible.module utils dependencies
- Why is this change needed?
- We received the deprecation warning for the dependencies that will be removed in 2.23 and 2.24 versions respectively. Hence this change was needed
- How does this change address the issue?
- Replaced the older dependencies with recommended dependencies to resolve the warning


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New module (adding a new module to the collection)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [x] Refactoring (no functional changes)
- [ ] Collection release
- [ ] CI maintenance
- [ ] Workflow maintenance
- [ ] Configuration change

## Related Issue
<!-- Optional: Link to related issue(s) -->
- Fixes #
- Related to #

## Component Name
<!-- Mandatory: Specify the module, plugin, or component being changed -->
eos
<!-- Examples: eos_config, eos_bgp_global, cliconf plugin, httpapi plugin, terminal plugin, etc. -->

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have removed all commented code (no commented code should be merged)
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] I have verified the changes work with the target EOS version(s)
- [x] I have reviewed the acceptance criteria for related tickets

## Testing Instructions
<!-- Mandatory for all changes: Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required (e.g., EOS version, hardware platform, test topology) -->
- EOS Version:
- Hardware Platform (if applicable):
- Test Topology:

### Steps to Test
1.Ran unit test
2.Ran Integration tests

### Expected Results
<!-- Describe what should happen after following the steps -->

### Test Results
<!-- Paste test output or describe test results -->
```
```

## Acceptance Criteria Verification
<!-- Mandatory: Verify that all acceptance criteria from the related ticket are met -->
- [x] All acceptance criteria have been reviewed and verified
- [x] Acceptance criteria checklist:
  - [x] Replace ansible.module_utils.common._collections_compat with collections.abc
  - [x] Replace imports from ansible.module_utils._text with ansible.module_utils.common.text.converters
  - [x] Replace ansible.module_utils.six with native Python 3 equivalents
  - [x]  All unit and integration tests pass
  - [x]  No deprecation warnings when running with ansible-core 2.20+



## Additional Context
<!-- Optional but helpful information -->
<!-- Include additional information to help people understand the change here -->
<!-- A step-by-step reproduction of the problem is helpful if there is no related issue -->

### Command Output / Logs
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
<!-- Paste below -->
```

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- Module documentation, examples, platform guides -->
- [ ] Requires changelog fragment
  <!-- Create changelog fragment if this is a user-facing change -->
- [ ] Requires integration test updates
- [ ] Requires unit test updates
- [ ] Requires coordination with other teams
- [x] Blocked by PR/MR: #https://github.com/ansible-collections/ansible.netcommon/pull/788
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
<!-- Include device output, error messages, or test results -->

### Breaking Changes
<!-- If this is a breaking change, describe the impact and migration path -->
<!-- Remove section if not applicable -->
